### PR TITLE
docs: improve newcomer/visitor experience

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,8 @@
 blank_issues_enabled: false
+contact_links:
+  - name: mloda documentation
+    url: https://mloda-ai.github.io/mloda/
+    about: Guides and reference for mloda and its plugins.
+  - name: mloda framework
+    url: https://github.com/mloda-ai/mloda
+    about: Questions about mloda itself, or to start a broader conversation.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+<!--
+NOTE: This guide is generic to every mloda plugin, not specific to open-kgo.
+The mloda-plugin-template ships a CONTRIBUTING.md that is template-only and is
+deleted on "Use this template", with no plugin-facing replacement — so every
+generated plugin starts without one. The durable fix is a plugin-facing
+community-health default in the template that survives scaffolding (tracked
+upstream); until then this lives here.
+-->
+
+# Contributing to open-kgo
+
+Thanks for your interest! open-kgo is a knowledge-graph connector plugin for
+[mloda](https://github.com/mloda-ai/mloda).
+
+## Development setup
+
+```bash
+uv venv && source .venv/bin/activate
+uv sync --all-extras
+```
+
+## Before you open a PR
+
+`tox` is the merge gate. It must pass:
+
+```bash
+tox
+```
+
+It runs pytest, `ruff format --check`, `ruff check`, `mypy --strict`, and bandit.
+
+## Ground rules
+
+- **Tests required.** Every feature or fix ships with tests — follow the
+  patterns in the existing `open_kgo/.../tests/` trees.
+- **No-Docker policy.** Connector tests run against in-memory libraries
+  (rdflib, networkx, kuzu) or file fixtures — no Docker, no network, no
+  external services. See `open_kgo/feature_groups/kg/README.md`.
+- **Conventional Commits.** Use `feat:` / `fix:` / `chore:` / `docs:` / etc.;
+  release tooling parses them. No `Co-Authored-By` / AI-agent trailers.
+
+## Reporting issues
+
+Use the issue template (Bug report / Feature request). One-sentence summary,
+reproduction or motivation, code pointers (`file:line`), and a definition of
+done if scoped.

--- a/README.md
+++ b/README.md
@@ -11,6 +11,48 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 - **[mloda](https://github.com/mloda-ai/mloda)**: The core library for open data access. Declaratively define what data you need, not how to get it.
 - **[mloda-registry](https://github.com/mloda-ai/mloda-registry)**: The central hub for discovering and sharing mloda plugins.
 
+## Quickstart
+
+Install the connectors and run a SPARQL query against the Turtle sample shipped in this repo — no Docker, no network:
+
+```bash
+uv sync --extra kg-all
+```
+
+```python
+from pathlib import Path
+
+from mloda.user import DataAccessCollection, Feature, Options, mloda
+
+import open_kgo.feature_groups.kg.rdf.rdflib_sparql as rdf_mod
+from open_kgo.feature_groups.kg.python_dict_kg_framework import KgPythonDictFramework
+
+# Point at any RDF file. Here: the Turtle sample shipped in this repo.
+ttl = Path(rdf_mod.__file__).parent / "tests" / "fixtures" / "sample.ttl"
+
+feature = Feature(
+    "rdflib_sparql__knows",
+    options=Options(context={
+        "query_text": "PREFIX foaf: <http://xmlns.com/foaf/0.1/> "
+                      "SELECT ?s ?o WHERE { ?s foaf:knows ?o }",
+    }),
+)
+
+partitions = mloda.run_all(
+    [feature],
+    compute_frameworks={KgPythonDictFramework},
+    data_access_collection=DataAccessCollection(
+        credentials=[{"rdflib_sparql": {"locator": str(ttl), "result_limit": 100}}],
+    ),
+)
+
+for partition in partitions:
+    for row in partition:
+        print(row[feature.name])
+```
+
+Swap `rdflib_sparql` for any of the nine connector families — same `Feature` → `mloda.run_all` shape, different reader.
+
 ## KG connectors
 
 `open_kgo/feature_groups/kg/` ships a 9-family knowledge-graph connector taxonomy (`network_pg`, `rdf`, `embedded`, `rest_public`, `lineage`, `code_build`, `saas_authz`, `agent_memory`, `citation_rest`), with at least one concrete plugin per family running against in-memory libraries or local file fixtures. See `open_kgo/feature_groups/kg/README.md` for the family map.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,32 @@
+<!--
+NOTE: This policy is generic to every mloda plugin, not specific to open-kgo.
+SECURITY.md is currently absent from mloda, mloda-registry, and
+mloda-plugin-template. The durable fix is a plugin-facing default in the
+template that survives scaffolding (tracked upstream); until then this lives here.
+-->
+
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security vulnerabilities **privately** — do not open a public
+GitHub issue. Either:
+
+- Email **security@mloda.ai** with a description, affected version, and
+  reproduction steps; or
+- Use GitHub's private vulnerability reporting: the repo **Security** tab →
+  **"Report a vulnerability"**.
+
+We aim to acknowledge reports within a few business days and will keep you
+updated on remediation. Once a fix is released, we're happy to credit you.
+
+## Supported versions
+
+open-kgo is pre-1.0; security fixes land on the latest release only.
+
+## Scope
+
+This project ships connectors that run against in-memory libraries and local
+file fixtures (no Docker, no network by policy). Reports about dependency CVEs
+surfaced by the weekly `pip-audit` scan (`.github/workflows/security-scan.yaml`)
+are welcome but are report-only and not release-blocking.


### PR DESCRIPTION
## Summary

Adds the onboarding and community-health files a visitor expects on landing, which the repo was missing. No code changes.

- **README — Quickstart.** A verified, runnable RDF/SPARQL example against the shipped `sample.ttl` fixture, so the core value prop (one `Feature` → `mloda.run_all`, swappable across all nine connector families) is visible without launching the marimo demos or clicking out to external docs.
- **`CONTRIBUTING.md`.** A human-facing contribution guide. The template ships a `CONTRIBUTING.md` that is template-only and removed on "Use this template" with no plugin-facing replacement, so generated plugins start without one. Points to the `tox` gate, conventional commits, and the no-Docker policy. (Durable fix tracked upstream: mloda-ai/mloda-plugin-template#64.)
- **`SECURITY.md`.** Private vulnerability-disclosure policy (security@mloda.ai + GitHub private reporting). GitHub's Community Standards previously flagged "Security policy: missing".
- **`.github/ISSUE_TEMPLATE/config.yml`.** Adds `contact_links` (mloda docs + framework repo) so the "New issue" chooser offers non-bug routes; Discussions were deliberately left out because they are not enabled (the URL 404s).

Also applied (not in this PR, as they are repo settings / other repos):
- Repo **topics + homepage** set via `gh repo edit` (knowledge-graph, ontology, rdf, sparql, mloda, sbom, python; homepage → mloda.ai).
- Upstream tracking issues for the missing community files: mloda-ai/mloda-plugin-template#64, mloda-ai/mloda#468, mloda-ai/mloda-registry#228.

## Verification

- Quickstart snippet run against the synced env — returns the three `foaf:knows` edges from the fixture.
- `config.yml` validated as well-formed YAML; both `contact_links` URLs return 200.
- No code changed, so the `tox` gate is unaffected (markdown/yaml only).