### PR TITLE
feat(demo): backend-swap cell + 2-hop QA accuracy eval

### DIFF
--- a/demo/data/__init__.py
+++ b/demo/data/__init__.py
@@ -16,6 +16,7 @@ from pathlib import Path
 DATA_DIR = Path(__file__).parent
 KB_FILE = DATA_DIR / "sample_kb.txt"
 QA_FILE = DATA_DIR / "sample_qa.txt"
+QA_2HOP_FILE = DATA_DIR / "sample_qa_2hop.txt"
 SAMPLE_FILE = DATA_DIR / "metaqa_sample.gml"
 
 

--- a/demo/data/sample_qa_2hop.txt
+++ b/demo/data/sample_qa_2hop.txt
@@ -1,0 +1,11 @@
+What movies share the same director with [The Dark Knight]	Inception
+Who starred in [Action] movies	Aaron Eckhart|Carrie-Anne Moss|Charlize Theron|Christian Bale|Elliot Page|Heath Ledger|Joseph Gordon-Levitt|Keanu Reeves|Laurence Fishburne|Leonardo DiCaprio|Nicholas Hoult|Tom Hardy
+Who directed [Crime] movies	Christopher Nolan|Francis Ford Coppola|Quentin Tarantino
+Who starred in movies released in [2001]	Audrey Tautou|Mathieu Kassovitz|Miyu Irino|Rumi Hiiragi
+Who directed movies released in [1999]	Lana Wachowski|Lilly Wachowski
+What language are [Science Fiction] movies in	English
+Who directed movies tagged [heist]	Christopher Nolan
+Who are the co-stars of [Keanu Reeves]	Carrie-Anne Moss|Laurence Fishburne
+What genres do movies from [2019] have	Drama|Thriller
+Who starred in movies tagged [dark comedy]	Cho Yeo-jeong|John Travolta|Lee Sun-kyun|Samuel L. Jackson|Song Kang-ho|Uma Thurman
+What release years do [Drama] movies have	1972|1994|2019

--- a/demo/data/sample_qa_2hop.txt
+++ b/demo/data/sample_qa_2hop.txt
@@ -9,3 +9,8 @@ Who are the co-stars of [Keanu Reeves]	Carrie-Anne Moss|Laurence Fishburne
 What genres do movies from [2019] have	Drama|Thriller
 Who starred in movies tagged [dark comedy]	Cho Yeo-jeong|John Travolta|Lee Sun-kyun|Samuel L. Jackson|Song Kang-ho|Uma Thurman
 What release years do [Drama] movies have	1972|1994|2019
+What movies share the same writer as [Inception]	The Dark Knight
+Who wrote movies directed by [Christopher Nolan]	Christopher Nolan|Jonathan Nolan
+What language are movies tagged [heist] in	English
+What genres do movies written by [Quentin Tarantino] have	Crime|Drama
+Who wrote [Science Fiction] movies	Christopher Nolan|David Koepp|Lana Wachowski|Lilly Wachowski|Michael Crichton

--- a/demo/demo_kg_ontology.py
+++ b/demo/demo_kg_ontology.py
@@ -387,6 +387,120 @@ def connector_demo(GML_FILE, ONTOLOGY_YAML, mo):
 
 
 @app.cell
+def section_backend_swap(mo):
+    mo.md("---\n## Backend swap — NetworkX → Kuzu")
+    return
+
+
+@app.cell
+def backend_swap(ONTOLOGY_YAML, OntologyRegistry, mo):
+    import gc as _gc
+    import shutil as _shutil
+    import tempfile as _tempfile
+
+    import importlib as _importlib
+
+    import kuzu as _kuzu
+
+    _importlib.import_module("open_kgo.feature_groups.kg.network_pg.kuzu_cypher")
+    from mloda.user import DataAccessCollection as _DAC
+    from mloda.user import Feature as _Feature
+    from mloda.user import Options as _Options
+    from mloda.user import mloda as _mloda
+
+    from open_kgo.feature_groups.kg.python_dict_kg_framework import KgPythonDictFramework as _KgFW
+
+    # Build a tiny Kuzu movie graph in a temp directory.
+    _tmp = _tempfile.mkdtemp(prefix="kg_demo_swap_")
+    _db_dir = _tmp + "/movies.kuzu"
+    _build_db = _kuzu.Database(_db_dir)
+    _build_conn = _kuzu.Connection(_build_db)
+    _build_conn.execute("CREATE NODE TABLE Movie(name STRING, PRIMARY KEY(name))")
+    _build_conn.execute("CREATE NODE TABLE Person(name STRING, PRIMARY KEY(name))")
+    _build_conn.execute("CREATE REL TABLE directed_by(FROM Movie TO Person)")
+    _build_conn.execute("CREATE (:Movie {name: 'The Dark Knight'})")
+    _build_conn.execute("CREATE (:Person {name: 'Christopher Nolan'})")
+    _build_conn.execute(
+        "MATCH (m:Movie {name: 'The Dark Knight'}), (p:Person {name: 'Christopher Nolan'}) "
+        "CREATE (m)-[:directed_by]->(p)"
+    )
+    # Release write handles before mloda opens the same DB directory.
+    del _build_conn
+    del _build_db
+    _gc.collect()
+
+    # Run through the Kuzu mloda connector — only the locator changes vs NetworkX.
+    _kuzu_creds = {
+        "locator": _db_dir,
+        "ontology": str(ONTOLOGY_YAML),
+    }
+    _feat = _Feature(
+        "kuzu_cypher__directed_by",
+        options=_Options(context={
+            "query_text": "MATCH (m:Movie)-[:directed_by]->(p:Person) RETURN m.name AS movie, p.name AS director",
+        }),
+    )
+    _dac = _DAC(credentials=[{"kuzu_cypher": _kuzu_creds}])
+    _partitions = _mloda.run_all(
+        [_feat],
+        compute_frameworks={_KgFW},
+        data_access_collection=_dac,
+    )
+    _kuzu_rows = [row[_feat.name] for part in _partitions for row in part if _feat.name in row]
+
+    # Same ontology YAML, same validation rules — only the credential locator changed.
+    _valid_edges = [
+        (
+            r["movie"],
+            "directed_by",
+            r["director"],
+            OntologyRegistry.is_valid_edge("movie", "Movie", "directed_by"),
+        )
+        for r in _kuzu_rows
+    ]
+    _invalid_attempt = OntologyRegistry.is_valid_edge("movie", "Person", "directed_by")
+
+    _shutil.rmtree(_tmp, ignore_errors=True)
+
+    _check_rows = "\n".join(
+        f"| `{src}` | `{rel}` | `{tgt}` | {'valid' if ok else 'invalid'} |"
+        for src, rel, tgt, ok in _valid_edges
+    )
+
+    mo.md(f"""
+    The **same ontology YAML** and the **same validation rules** apply unchanged when the
+    storage backend changes. Only the connector credentials change — the `locator` and the
+    connector id (`networkx_embedded` → `kuzu_cypher`).
+
+    ```python
+    # NetworkX, file-backed, in-process
+    networkx_creds = {{
+        "locator":           "metaqa_sample.gml",
+        "graph_file_format": "gml",
+        "ontology":          "metaqa_ontology.yaml",  # travels with the swap
+    }}
+
+    # Kuzu, embedded Cypher engine — one credential change
+    kuzu_creds = {{
+        "locator":  "/path/to/movies.kuzu",           # locator changes
+        "ontology": "metaqa_ontology.yaml",           # same YAML, same rules
+    }}
+    ```
+
+    **Data fetched from Kuzu via `mloda.run_all`:**
+
+    | Source | Relation | Target | Ontology check |
+    |---|---|---|---|
+    {_check_rows}
+
+    **Same rule, wrong source type:** `is_valid_edge("movie", "Person", "directed_by")` → `{_invalid_attempt}`
+
+    The ontology YAML is the single source of truth. The backend is swappable.
+    """)
+    return
+
+
+@app.cell
 def section_standalone(mo):
     mo.md("---\n## Standalone API (no mloda required)")
     return

--- a/demo/eval_qa_accuracy_2hop.py
+++ b/demo/eval_qa_accuracy_2hop.py
@@ -1,0 +1,463 @@
+import marimo
+
+__generated_with = "0.23.4"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def title(mo):
+    mo.md("""
+    # 2-hop QA Accuracy: Arch 1 vs Arch 2
+
+    Measures answer accuracy on the committed 2-hop sample QA set
+    (`demo/data/sample_qa_2hop.txt`), a small hand-authored set of public movie
+    facts in MetaQA's triple format.
+
+    **Architecture 1:** plain traversal — follow any matching edge, no type checking.
+    **Architecture 2:** ontology-guided — entity type validated before each forward hop,
+    range type validated on arrival. Reverse hops are unchecked in both architectures.
+
+    2-hop questions chain two relations through the movie KB. Two structural patterns:
+
+    - **Non-Movie start:** `[Person/Genre/Year/Tag] <-(rev rel1)- Movies -(fwd rel2)-> Answer`
+    - **Movie start (same-X):** `[Movie] -(fwd rel1)-> Entity <-(rev rel1)- Other Movies`
+
+    Metric: **hit rate** — question answered correctly if the returned set contains
+    at least one gold answer.
+    """)
+    return
+
+
+@app.cell
+def _():
+    import re
+    import sys
+    from collections import defaultdict
+    from pathlib import Path
+
+    import networkx as nx
+
+    from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
+
+    DEMO_DIR = Path(__file__).parent
+    DATA_DIR = DEMO_DIR / "data"
+    _ROOT = DEMO_DIR.parent
+    if str(_ROOT) not in sys.path:
+        sys.path.insert(0, str(_ROOT))
+    from demo.data import ensure_data
+
+    ensure_data()
+    ONTOLOGY_YAML = (
+        Path(__file__).parent.parent
+        / "open_kgo"
+        / "feature_groups"
+        / "kg"
+        / "ontology"
+        / "tests"
+        / "fixtures"
+        / "metaqa_ontology.yaml"
+    )
+    QA_2HOP = DATA_DIR / "sample_qa_2hop.txt"
+    GML_FILE = DATA_DIR / "metaqa_sample.gml"
+
+    OntologyRegistry._clear()
+    OntologyRegistry.load_file(str(ONTOLOGY_YAML))
+
+    graph: nx.MultiDiGraph = nx.read_gml(str(GML_FILE))
+
+    return (
+        DATA_DIR,
+        DEMO_DIR,
+        GML_FILE,
+        ONTOLOGY_YAML,
+        OntologyRegistry,
+        Path,
+        QA_2HOP,
+        defaultdict,
+        graph,
+        nx,
+        re,
+    )
+
+
+@app.cell
+def graph_info(graph, mo):
+    _types: dict[str, int] = {}
+    for _, _d in graph.nodes(data=True):
+        _t = _d.get("type", "Unknown")
+        _types[_t] = _types.get(_t, 0) + 1
+    _rows = "\n".join(f"| {t} | {c} |" for t, c in sorted(_types.items()))
+    mo.md(f"""
+    **QA-anchored subgraph:** {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges
+
+    Built by `demo/data/build_sample.py` as the 1-hop induced subgraph around
+    every QA topic entity. All 10 movies are 1-hop topics in the 1-hop QA set,
+    so the subgraph covers the full KB and all 2-hop answers are reachable.
+
+    | Entity type | Count |
+    |---|---|
+    {_rows}
+    """)
+    return
+
+
+@app.cell
+def _():
+    # ---------------------------------------------------------------------------
+    # Traversal primitives
+    # ---------------------------------------------------------------------------
+
+    def arch1_hop(g, start: str, relation: str) -> set[str]:
+        """Forward hop — no type checking."""
+        if start not in g:
+            return set()
+        return {t for _, t, d in g.out_edges(start, data=True) if d.get("relation") == relation}
+
+    def arch2_hop(g, start: str, relation: str, namespace: str = "movie") -> set[str]:
+        """Forward hop — ontology-validated domain + range."""
+        from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry as _OR
+
+        entity_type = g.nodes[start].get("type", "Unknown")
+        if not _OR.is_valid_edge(namespace, entity_type, relation):
+            raise ValueError(f"Ontology violation: '{relation}' from '{entity_type}'")
+        expected_range = _OR.get_range_type(namespace, relation)
+        seen: set[str] = set()
+        for _, t, d in g.out_edges(start, data=True):
+            if d.get("relation") != relation:
+                continue
+            if expected_range is not None:
+                target_type = g.nodes[t].get("type", "Unknown")
+                if target_type != expected_range:
+                    raise ValueError(
+                        f"Range violation: '{relation}' expects '{expected_range}' "
+                        f"but reached '{t}' of type '{target_type}'"
+                    )
+            seen.add(t)
+        return seen
+
+    def rev_hop(g, target: str, relation: str) -> set[str]:
+        """Reverse hop — find all nodes pointing to target via relation."""
+        return {s for s, t, d in g.in_edges(target, data=True) if d.get("relation") == relation}
+
+    return arch1_hop, arch2_hop, rev_hop
+
+
+@app.cell
+def _(arch1_hop, arch2_hop, rev_hop):
+    # ---------------------------------------------------------------------------
+    # 2-hop traversal
+    # ---------------------------------------------------------------------------
+
+    def traverse_2hop_arch1(g, entity: str, rel1: str, dir1: str, rel2: str, dir2: str) -> set[str]:
+        """Chain two hops — no ontology checking."""
+        if dir1 == "forward":
+            intermediates = arch1_hop(g, entity, rel1)
+        else:
+            intermediates = rev_hop(g, entity, rel1)
+
+        answers: set[str] = set()
+        for mid in intermediates:
+            if mid not in g:
+                continue
+            if dir2 == "forward":
+                answers |= arch1_hop(g, mid, rel2)
+            else:
+                answers |= rev_hop(g, mid, rel2)
+        return answers
+
+    def traverse_2hop_arch2(g, entity: str, rel1: str, dir1: str, rel2: str, dir2: str) -> tuple[set[str], int]:
+        """Chain two hops — ontology-validated on forward hops.
+
+        Returns (answer_set, n_blocked) where n_blocked counts forward hops
+        that raised a ValueError.
+        """
+        blocked = 0
+
+        if dir1 == "forward":
+            try:
+                intermediates = arch2_hop(g, entity, rel1)
+            except ValueError:
+                return set(), 1
+        else:
+            intermediates = rev_hop(g, entity, rel1)
+
+        answers: set[str] = set()
+        for mid in intermediates:
+            if mid not in g:
+                continue
+            if dir2 == "forward":
+                try:
+                    answers |= arch2_hop(g, mid, rel2)
+                except ValueError:
+                    blocked += 1
+            else:
+                answers |= rev_hop(g, mid, rel2)
+
+        return answers, blocked
+
+    return traverse_2hop_arch1, traverse_2hop_arch2
+
+
+@app.cell
+def _():
+    # ---------------------------------------------------------------------------
+    # 2-hop question parser
+    # Returns (rel1, dir1, rel2, dir2) or None
+    # ---------------------------------------------------------------------------
+
+    def infer_2hop_chain(question: str, entity_type: str) -> tuple[str, str, str, str] | None:
+        q = question.lower()
+
+        # Movie-start: fwd(rel1) -> Entity <- rev(rel1) <- Other Movies
+        if entity_type == "Movie":
+            if any(k in q for k in ["same director", "also directed", "director of", "directed by the same", "share a director"]):
+                return ("directed_by", "forward", "directed_by", "reverse")
+            if any(
+                k in q
+                for k in [
+                    "same actor",
+                    "share the same actor",
+                    "have the same actor",
+                    "same movie with",
+                    "co-star",
+                    "actor of",
+                    "actor in",
+                    "also starred in",
+                    "also appears in",
+                ]
+            ):
+                return ("starred_actors", "forward", "starred_actors", "reverse")
+            if any(
+                k in q
+                for k in [
+                    "same screenwriter",
+                    "same writer",
+                    "same screenplay",
+                    "have the same screenwriter",
+                    "same screenplay writer",
+                    "scriptwriter",
+                    "screenwriter of",
+                    "screenwriter with",
+                    "share the screenwriter",
+                ]
+            ):
+                return ("written_by", "forward", "written_by", "reverse")
+            return None
+
+        # Non-Movie start: Entity <- rev(rel1) <- Movies -> fwd(rel2) -> Answer
+
+        # Determine rel1 (the entity's role w.r.t. movies)
+        if entity_type == "Person":
+            if any(
+                k in q
+                for k in [
+                    "directed by",
+                    "films directed",
+                    "movies directed",
+                    "the director",
+                    "co-direct",
+                    "director of",
+                ]
+            ):
+                rel1 = "directed_by"
+            elif any(
+                k in q
+                for k in [
+                    "written by",
+                    "films written",
+                    "movies written",
+                    "screenwriter",
+                    "co-wrote",
+                    "co-writers",
+                    "co-written",
+                    "wrote",
+                    "written films",
+                ]
+            ):
+                rel1 = "written_by"
+            else:
+                rel1 = "starred_actors"
+        elif entity_type == "Genre":
+            rel1 = "has_genre"
+        elif entity_type == "Language":
+            rel1 = "in_language"
+        elif entity_type == "Year":
+            rel1 = "release_year"
+        elif entity_type == "Tag":
+            rel1 = "has_tags"
+        else:
+            return None
+
+        # Determine rel2 (the answer type)
+        if any(k in q for k in ["directed", "director", "co-director", "co-directed"]):
+            rel2 = "directed_by"
+        elif any(
+            k in q
+            for k in [
+                "actors",
+                "acted",
+                "starred",
+                "appeared in the same",
+                "acted together",
+                "who starred",
+                "acted by",
+                "co-star",
+            ]
+        ):
+            rel2 = "starred_actors"
+        elif any(k in q for k in ["written by", "wrote", "screenwriter", "co-writ", "co-writer"]):
+            rel2 = "written_by"
+        elif any(k in q for k in ["genre", "types", "kind", "sort", "fall under"]):
+            rel2 = "has_genre"
+        elif any(k in q for k in ["language"]):
+            rel2 = "in_language"
+        elif any(
+            k in q
+            for k in [
+                "release year",
+                "release date",
+                "when were",
+                "when was",
+                "released in which year",
+                "release dates",
+                "release years",
+            ]
+        ):
+            rel2 = "release_year"
+        elif any(k in q for k in ["tags", "topics", "about", "applicable", "terms", "words"]):
+            rel2 = "has_tags"
+        else:
+            return None
+
+        return (rel1, "reverse", rel2, "forward")
+
+    return (infer_2hop_chain,)
+
+
+@app.cell
+def _():
+    # ---------------------------------------------------------------------------
+    # Question loader
+    # ---------------------------------------------------------------------------
+
+    def load_qa(path) -> list[tuple[str, set[str]]]:
+        """Load (question, gold_answer_set) pairs from a MetaQA QA file."""
+        rows = []
+        with open(path, encoding="utf-8") as f:
+            for line in f:
+                parts = line.strip().split("\t")
+                if len(parts) != 2:
+                    continue
+                q, raw_answers = parts
+                rows.append((q, {a.strip() for a in raw_answers.split("|")}))
+        return rows
+
+    return (load_qa,)
+
+
+@app.cell
+def run_eval(
+    QA_2HOP,
+    defaultdict,
+    graph,
+    infer_2hop_chain,
+    load_qa,
+    mo,
+    re,
+    traverse_2hop_arch1,
+    traverse_2hop_arch2,
+):
+    _qa = load_qa(QA_2HOP)
+
+    # Per-chain-key counters: [hits, total]
+    _a1: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    _a2: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    _skipped = 0
+    _arch2_blocked_total = 0
+    _disagreements = 0
+
+    for _q, _gold in _qa:
+        _m = re.search(r"\[(.+?)\]", _q)
+        if not _m:
+            _skipped += 1
+            continue
+
+        _entity = _m.group(1)
+        if _entity not in graph:
+            _skipped += 1
+            continue
+
+        _entity_type = graph.nodes[_entity].get("type", "Unknown")
+        _chain = infer_2hop_chain(_q, _entity_type)
+        if _chain is None:
+            _skipped += 1
+            continue
+
+        _rel1, _dir1, _rel2, _dir2 = _chain
+        _chain_key = f"{_rel1}({_dir1[:3]}) -> {_rel2}({_dir2[:3]})"
+
+        # Architecture 1
+        _r1 = traverse_2hop_arch1(graph, _entity, _rel1, _dir1, _rel2, _dir2)
+        _hit1 = bool(_r1 & _gold)
+        _a1[_chain_key][0] += int(_hit1)
+        _a1[_chain_key][1] += 1
+
+        # Architecture 2
+        _r2, _blocked = traverse_2hop_arch2(graph, _entity, _rel1, _dir1, _rel2, _dir2)
+        _hit2 = bool(_r2 & _gold)
+        _arch2_blocked_total += _blocked
+        _a2[_chain_key][0] += int(_hit2)
+        _a2[_chain_key][1] += 1
+
+        if _hit1 != _hit2:
+            _disagreements += 1
+
+    # Build results table
+    _all_chains = sorted(set(_a1) | set(_a2))
+    _rows_md = ""
+    _total_a1_hits = _total_a2_hits = _total_qs = 0
+    for _ck in _all_chains:
+        _h1, _n1 = _a1[_ck]
+        _h2, _n2 = _a2[_ck]
+        _pct1 = f"{100 * _h1 // _n1}%" if _n1 else "—"
+        _pct2 = f"{100 * _h2 // _n2}%" if _n2 else "—"
+        _diff = "**DIFF**" if _h1 != _h2 else ""
+        _rows_md += f"| `{_ck}` | {_n1} | {_h1} ({_pct1}) | {_h2} ({_pct2}) | {_diff} |\n"
+        _total_a1_hits += _h1
+        _total_a2_hits += _h2
+        _total_qs += _n1
+
+    _overall1 = f"{100 * _total_a1_hits // _total_qs}%" if _total_qs else "—"
+    _overall2 = f"{100 * _total_a2_hits // _total_qs}%" if _total_qs else "—"
+
+    mo.md(f"""
+    ## Results
+
+    **Test questions:** {len(_qa)} total — {_total_qs} evaluated, {_skipped} skipped
+    (skipped = entity not in graph or question template not recognised)
+
+    | Chain | Questions | Arch 1 hit rate | Arch 2 hit rate | |
+    |---|---|---|---|---|
+    {_rows_md}
+    | **TOTAL** | **{_total_qs}** | **{_overall1}** | **{_overall2}** | |
+
+    **Disagreements (arch1 hit ≠ arch2 hit):** {_disagreements}
+    **Arch 2 forward-hop blocks across all hops:** {_arch2_blocked_total}
+
+    > Hit rate = % of questions where at least one gold answer is in the returned set.
+    > Reverse hops use the same traversal in both architectures (no source-type constraint applies).
+    > Forward hops in Arch 2 are validated: domain entity type + range type checked per hop.
+    > On this type-clean sample, both architectures should agree and hit 100%.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()


### PR DESCRIPTION
## Summary

Ports the demo-facing parts of [prototypes PR #40](https://github.com/mloda-ai/prototypes/pull/40) into open-kgo. The ontology layer itself was already imported during bootstrap, so this PR carries only the genuinely new deltas from that branch, adapted to open-kgo's package layout, connector API, and data policy.

- **Backend-swap cell** in `demo/demo_kg_ontology.py`: shows the same ontology YAML and validation rules travel unchanged from NetworkX to Kuzu, with only the connector id and `locator` changing. Builds a tiny Kuzu movie graph inline and runs it through open-kgo's `kuzu_cypher` mloda connector with the same `ontology` credential key used by the NetworkX cell, so the swap runs through mloda end to end (independently verified to return `['Christopher Nolan']`).
- **2-hop QA accuracy eval** (`demo/eval_qa_accuracy_2hop.py`): mirrors the 1-hop eval, scoring 2-hop relation chains (forward + reverse) under plain traversal (Arch 1) vs ontology-guided traversal (Arch 2).
- **Hand-authored 2-hop sample** (`demo/data/sample_qa_2hop.txt`, 11 pairs) + `QA_2HOP_FILE` constant: instead of vendoring the full 14,872-question MetaQA 2-hop set (CC BY 3.0, never redistributed here), the eval runs against a small committed sample over the existing sample movie graph, consistent with open-kgo's offline "committed runnable sample" data policy. Every gold answer was verified by computing it from the built graph.

## Adaptations vs the prototype

- Package paths `mloda_prototypes` → `open_kgo`; ontology fixture path under `open_kgo/...`.
- Backend-swap drives open-kgo's real Kuzu mloda connector via `mloda.run_all` (the prototype used the raw kuzu API only); the build connection is released before mloda re-opens the DB (Kuzu single-writer lock). Kuzu DDL/Cypher confirmed against the installed 0.11.x.
- 2-hop eval is sample-driven and lean, matching `eval_qa_accuracy.py`'s structure rather than the prototype's full-dataset harness; long parser keyword lists wrapped to stay readable.
- No large MetaQA data vendored.

## Results on the sample

All 11 2-hop questions evaluate (0 skipped); Arch 1 and Arch 2 agree at 100% with zero ontology blocks, matching the PR's finding that ontology validation is transparent on structurally valid paths. (Arch 2's collision-catching shows up on the full noisy KB; the clean hand-authored sample has no type-collision artefacts.)

## Test plan

- [x] `pytest -m "not notebooks"` — 530 passed, 25 skipped
- [x] `ruff format --check --line-length 120 .`, `ruff check .`, `mypy --strict --ignore-missing-imports .`, `bandit` — all clean
- [x] Both new/changed notebooks (`demo_kg_ontology.py`, `eval_qa_accuracy_2hop.py`) execute headlessly via `marimo export html` (exit 0)
- [x] 2-hop sample answers independently re-verified against the built graph (11/11, both architectures)
- [x] Kuzu connector path independently verified to return non-empty neighbors

Checks were run via the project venv under Python 3.12 (no 3.10 interpreter available locally); commands match the `tox` gate. `tox -e security` (pip-audit) is the weekly, report-only CVE job and not part of the PR merge gate.
