### PR TITLE
fix: ship py.typed marker and drop decorative request_timeout_ms

### DIFF
--- a/open_kgo/feature_groups/kg/base.py
+++ b/open_kgo/feature_groups/kg/base.py
@@ -120,6 +120,15 @@ def narrow_property_mapping(source: dict[str, Any], *exclude: str) -> dict[str, 
 # networked concrete has something to call without re-implementing the
 # env-var-resolution contract.
 
+# The same reasoning retired ``request_timeout_ms``. It was a universal
+# property with a 30_000ms default, but no shipped concrete opens a network
+# socket, so no ``_connect_from_slot`` / ``load_data`` ever read it — the
+# framework validated and defaulted a timeout surface that bounded nothing
+# (``embedded/base.py`` even documented it as semantically optional). Keeping
+# it while dropping ``auth_method`` for the identical "decorative surface"
+# reason was inconsistent. Re-introduce it per-concrete (or per-family) when a
+# networked concrete actually enforces a per-request timeout.
+
 
 _UNIVERSAL_PROPERTY_MAPPING: dict[str, Any] = {
     "locator": {
@@ -140,12 +149,6 @@ _UNIVERSAL_PROPERTY_MAPPING: dict[str, Any] = {
         DefaultOptionKeys.context: True,
         DefaultOptionKeys.strict_validation: False,
         DefaultOptionKeys.default: None,
-    },
-    "request_timeout_ms": {
-        "explanation": "Per-request wall-clock timeout in milliseconds.",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: False,
-        DefaultOptionKeys.default: 30_000,
     },
     "result_limit": {
         "explanation": (

--- a/open_kgo/feature_groups/kg/base.py
+++ b/open_kgo/feature_groups/kg/base.py
@@ -120,15 +120,6 @@ def narrow_property_mapping(source: dict[str, Any], *exclude: str) -> dict[str, 
 # networked concrete has something to call without re-implementing the
 # env-var-resolution contract.
 
-# The same reasoning retired ``request_timeout_ms``. It was a universal
-# property with a 30_000ms default, but no shipped concrete opens a network
-# socket, so no ``_connect_from_slot`` / ``load_data`` ever read it — the
-# framework validated and defaulted a timeout surface that bounded nothing
-# (``embedded/base.py`` even documented it as semantically optional). Keeping
-# it while dropping ``auth_method`` for the identical "decorative surface"
-# reason was inconsistent. Re-introduce it per-concrete (or per-family) when a
-# networked concrete actually enforces a per-request timeout.
-
 
 _UNIVERSAL_PROPERTY_MAPPING: dict[str, Any] = {
     "locator": {

--- a/open_kgo/feature_groups/kg/embedded/base.py
+++ b/open_kgo/feature_groups/kg/embedded/base.py
@@ -32,8 +32,7 @@ class EmbeddedGraphReader(ParamReader):
 
     Concrete plugins (NetworkxEmbeddedReader, IGraphReader, ...) load a graph
     object from a filesystem path or accept ``locator=None`` for empty graph.
-    Auth is always ``none``; network properties (``request_timeout_ms``) are
-    semantically optional.
+    The backend is in-process, so there is no network surface to configure.
 
     Per-call inputs (``operation``, ``start_node``) live on
     ``PARAMS_MAPPING`` rather than being read raw from

--- a/open_kgo/feature_groups/kg/tests/test_cross_group_contract.py
+++ b/open_kgo/feature_groups/kg/tests/test_cross_group_contract.py
@@ -75,8 +75,8 @@ def test_connector_ids_disjoint_from_property_names() -> None:
     Issue #18 C3: ``_wrap_credentials`` uses ``cls.CONNECTOR_ID in data_access``
     as the "is this already wrapped?" heuristic (``base.py``). If a plugin's
     ``CONNECTOR_ID`` coincides with *any* declared slot key — including its
-    own family's keys and the universal ``locator``, ``request_timeout_ms``,
-    ``result_limit`` that every reader inherits from
+    own family's keys and the universal ``locator``, ``result_limit`` that
+    every reader inherits from
     ``_UNIVERSAL_PROPERTY_MAPPING`` — a bare slot dict would misclassify as a
     wrapper and get handed to the reader without the outer normalisation
     step. The realistic failure mode is therefore not a cross-family

--- a/open_kgo/feature_groups/kg/tests/test_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/test_helpers.py
@@ -203,9 +203,9 @@ def test_make_valid_credentials_returns_wrapped_form_with_connector_id() -> None
 def test_make_valid_credentials_prefills_spec_defaults() -> None:
     """Spec defaults are pre-populated; the caller only supplies the rest.
 
-    ``result_limit`` and ``request_timeout_ms`` carry explicit non-``None``
-    defaults on the universal base; the helper must lift those into the slot
-    so the caller doesn't re-spell family-level scaffolding.
+    ``result_limit`` carries an explicit non-``None`` default on the universal
+    base; the helper must lift it into the slot so the caller doesn't re-spell
+    family-level scaffolding.
     """
     creds = make_valid_credentials(
         FileFixtureCitationReader,
@@ -213,7 +213,6 @@ def test_make_valid_credentials_prefills_spec_defaults() -> None:
     )
     slot = creds[FileFixtureCitationReader.CONNECTOR_ID]
     assert slot["result_limit"] == 1000
-    assert slot["request_timeout_ms"] == 30_000
 
 
 def test_make_valid_credentials_override_wins_over_default() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,12 @@ demo = ["marimo", "open-kgo[kg-all]"]
 where = ["."]
 include = ["open_kgo*"]
 
+# Ship the PEP 561 marker so the `Typing :: Typed` classifier is honoured:
+# without it, mypy/pyright in downstream projects ignore this package's inline
+# types even though every module is fully annotated.
+[tool.setuptools.package-data]
+open_kgo = ["py.typed"]
+
 [tool.pytest.ini_options]
 testpaths = ["open_kgo", "tests"]
 python_files = ["test_*.py"]


### PR DESCRIPTION
## Summary

Two small consistency fixes to the KG connector base. No behavior change for working callers; the full `tox` gate passes (530 passed, 26 skipped; ruff, mypy --strict, bandit all clean).

## 1. Ship the `py.typed` marker

`pyproject.toml` advertises `"Typing :: Typed"`, but the package shipped no PEP 561 marker. Without it, mypy/pyright in downstream projects ignore this package's inline types even though every module is fully annotated, so the classifier was writing a check the wheel didn't cash.

- Add `open_kgo/py.typed`.
- Wire it into the wheel via `[tool.setuptools.package-data]` (with `packages.find`, the marker is not packaged automatically). Verified present in the built wheel: `open_kgo/py.typed` appears in `unzip -l dist/*.whl`.

## 2. Drop decorative `request_timeout_ms`

`request_timeout_ms` was a universal property (default 30000ms), but no shipped concrete opens a network socket, so no `_connect_from_slot` / `load_data` ever read it. The framework validated and defaulted a timeout surface that bounded nothing (`embedded/base.py` even documented it as semantically optional).

This is the same "decorative surface" reasoning that retired `auth_method` (#32 item 2). Keeping the timeout while dropping auth was inconsistent. The key can be re-introduced per-concrete (or per-family) when a networked concrete actually enforces a per-request timeout.

Touched the two test/docstring references that named the key (`test_helpers.py`, `test_cross_group_contract.py`) and the `embedded/base.py` family docstring.

## Definition of done

- [x] `py.typed` present in the built wheel
- [x] `request_timeout_ms` removed from `_UNIVERSAL_PROPERTY_MAPPING` and all references
- [x] `tox` green (pytest, ruff format/check, mypy --strict, bandit)