### PR TITLE
feat: add a second concrete plugin to each of the 9 KG families

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Swap `rdflib_sparql` for any of the nine connector families â€” same `Feature` â
 
 ## KG connectors
 
-`open_kgo/feature_groups/kg/` ships a 9-family knowledge-graph connector taxonomy (`network_pg`, `rdf`, `embedded`, `rest_public`, `lineage`, `code_build`, `saas_authz`, `agent_memory`, `citation_rest`), with at least one concrete plugin per family running against in-memory libraries or local file fixtures. See `open_kgo/feature_groups/kg/README.md` for the family map.
+`open_kgo/feature_groups/kg/` ships a 9-family knowledge-graph connector taxonomy (`network_pg`, `rdf`, `embedded`, `rest_public`, `lineage`, `code_build`, `saas_authz`, `agent_memory`, `citation_rest`), with two concrete plugins per family running against in-memory libraries or local file fixtures. See `open_kgo/feature_groups/kg/README.md` for the family map.
 
 Install all KG extras with: `uv sync --extra kg-all`.
 

--- a/open_kgo/feature_groups/kg/README.md
+++ b/open_kgo/feature_groups/kg/README.md
@@ -3,22 +3,25 @@
 Nine families derived from a 103-system survey (see
 `docs/kg-connector-base-classes.md` Version B). Each family is a
 `<Family>Reader(KgConnectorReaderBase)` + `<Family>FeatureGroup`, paired with
-at least one concrete plugin that runs against in-memory libraries or local
-fixture files. No Docker, no external services.
+**two** concrete plugins that run against in-memory libraries or local fixture
+files. No Docker, no external services. The second concrete per family is
+either a different backend on the same contract (backend variety) or a backend
+that exercises family surface the first concrete narrows / strips (see
+issue #16); the **New surface** column records which.
 
 ## Family map
 
-| Family | Concrete plugin | Pedigree | Notes |
+| Family | Concrete plugins | Pedigree | New surface vs. first plugin |
 |---|---|---|---|
-| `network_pg` | `KuzuCypherReader` | Real Python lib (`kuzu`) | Embedded but Cypher-shaped. Does NOT exercise `read_consistency` / `transaction_mode`. |
-| `rdf` | `RdfLibSparqlReader` | Real Python lib (`rdflib`) | Canonical fit — in-memory Graph + SPARQL. |
-| `embedded` | `NetworkxEmbeddedReader` | Real Python lib (`networkx`) | Loads `.gml` from `locator` (filesystem path; no network). |
-| `rest_public` | `FileFixtureRestReader` | Prototype + JSON fixtures | Pagination/cursor against static `page_<N>.json`; `pagination_style` narrowed to `cursor` via `SUPPORTED_VALUES`; `page_size` rejected at credential time, `cursor_token` / `entity_type` rejected at per-call time (`_STRIPPED_PARAMS`). No real `rate_limit_pace`. |
-| `lineage` | `DbtManifestReader` | Real artifact (dbt manifest.json) | Walks `parent_map` / `child_map`. |
-| `code_build` | `CycloneDxSbomReader` | Real artifact (CycloneDX) | Parses fixture SBOM components; does not walk the `dependencies` graph; all TraversalMixin / EntityFilter keys rejected at per-call time (`_STRIPPED_PARAMS`). |
-| `saas_authz` | `InProcessTupleStoreReader` | Prototype | Zanzibar-shaped tuple list. Validates property shape only — no real consistency-token semantics. |
-| `agent_memory` | `NetworkxMemoryReader` | Prototype on top of NetworkX | Lexical search only; vector / hybrid / graph rejected at validate-time via `SUPPORTED_VALUES`. |
-| `citation_rest` | `FileFixtureCitationReader` | Prototype + JSON fixture | Reactome-shaped catalog with ancestor walk; `pagination_style` / `page_size` rejected at credential time, `cursor_token` / `entity_type` rejected at per-call time (`_STRIPPED_PARAMS`). |
+| `network_pg` | `KuzuCypherReader`, `GrandCypherReader` | Real Python libs (`kuzu`; `grand-cypher` over `networkx`) | None — both embedded, so `read_consistency` / `transaction_mode` stay waived. Second Cypher engine. |
+| `rdf` | `RdfLibSparqlReader`, `OxigraphSparqlReader` | Real Python libs (`rdflib`; `pyoxigraph`) | None — `result_format` / `reasoning_profile` stay narrowed on both. Second SPARQL engine. |
+| `embedded` | `NetworkxEmbeddedReader`, `IGraphEmbeddedReader` | Real Python libs (`networkx`; `igraph`) | None — same formats / operations. Second embedded graph lib. |
+| `rest_public` | `FileFixtureRestReader`, `FileFixturePagedRestReader` | Prototype + JSON fixtures | **`pagination_style=page` + `page_size`** (cursor concrete narrows to `cursor` and drops `page_size`). |
+| `lineage` | `DbtManifestReader`, `OpenLineageReader` | Real artifacts (dbt `manifest.json`; OpenLineage run-event JSON) | None — both walk UPSTREAM / DOWNSTREAM / BOTH. Second lineage artifact. |
+| `code_build` | `CycloneDxSbomReader`, `SpdxSbomReader` | Real artifacts (CycloneDX; SPDX) | **TraversalMixin** (`lineage_direction` / `upstream_depth` / `downstream_depth`) — SPDX walks the `DEPENDS_ON` graph the CycloneDX concrete strips. |
+| `saas_authz` | `InProcessTupleStoreReader`, `PaginatedTupleStoreReader` | Prototype | **`pagination_style=cursor` + `page_size` + `cursor_token` + `expand_paths`** (structural group expansion; still no real consistency-token semantics). |
+| `agent_memory` | `NetworkxMemoryReader`, `GraphWalkMemoryReader` | Prototype on top of NetworkX | **`retrieval_mode=graph`** (lexical concrete narrows to `lexical`). |
+| `citation_rest` | `FileFixtureCitationReader`, `PaginatedCitationReader` | Prototype + JSON fixtures | **`pagination_style=cursor` + `page_size` + `cursor_token` + `entity_type`** (Reactome concrete drops / strips them). |
 
 ## Layout
 
@@ -107,14 +110,21 @@ infrastructure.
 
 ## What this prototype does NOT validate
 
-- **`network_pg`**: KuzuDB is embedded; `read_consistency`, `transaction_mode`,
-  routing, bookmarks are no-ops. Real Neo4j / Memgraph / Neptune behavior is
-  out of scope.
-- **`saas_authz`**: in-process tuple store has no Zanzibar consistency tokens,
-  no model-id versioning, no namespaced check evaluation.
-- **`citation_rest`** / **`rest_public`**: file fixtures exercise pagination
-  shape but not real `rate_limit_pace` enforcement.
-- **`agent_memory`**: only `retrieval_mode=lexical` is implemented; the
-  other family-level values (`vector`, `hybrid`, `graph`) are rejected at
-  `is_valid_credentials` time via `SUPPORTED_VALUES` so the surface does
-  not lie about what this concrete honors.
+- **`network_pg`**: both concretes (KuzuDB, GrandCypher) are embedded;
+  `read_consistency`, `transaction_mode`, routing, bookmarks are no-ops. Real
+  Neo4j / Memgraph / Neptune behavior is out of scope.
+- **`saas_authz`**: neither tuple-store concrete implements real Zanzibar
+  consistency tokens, model-id versioning, or namespaced check evaluation.
+  `PaginatedTupleStoreReader` adds cursor pagination and *structural*
+  `expand_paths` group expansion, but the expansion is a single in-process
+  pass, not a real userset-rewrite evaluator.
+- **`citation_rest`** / **`rest_public`**: file fixtures exercise both
+  pagination shapes (cursor and page-number, across the two concretes per
+  family) but not real `rate_limit_pace` enforcement.
+- **`rdf`**: both SPARQL engines (rdflib, oxigraph) return JSON-binding-shaped
+  rows and have no inference, so `result_format` stays narrowed to JSON and
+  `reasoning_profile` to `none`.
+- **`agent_memory`**: `retrieval_mode=lexical` (NetworkxMemoryReader) and
+  `retrieval_mode=graph` (GraphWalkMemoryReader) are implemented; `vector` /
+  `hybrid` remain rejected at `is_valid_credentials` time via
+  `SUPPORTED_VALUES` so neither concrete lies about what it honors.

--- a/open_kgo/feature_groups/kg/agent_memory/__init__.py
+++ b/open_kgo/feature_groups/kg/agent_memory/__init__.py
@@ -18,7 +18,10 @@ live on the family base for future concrete readers (Mem0, Zep+Graphiti,
 Letta) that own their own per-tenant stores.
 
 PROTOTYPE NOTE: ``retrieval_mode`` is strict-validated against
-``{lexical, vector, hybrid, graph}`` but only ``lexical`` is implemented;
-``vector``/``hybrid``/``graph`` raise ``NotImplementedError`` at
-``load_data`` time (see ``networkx_memory.py``).
+``{lexical, vector, hybrid, graph}``. ``NetworkxMemoryReader`` narrows it to
+``lexical`` (string-match over node labels); ``GraphWalkMemoryReader``
+narrows it to ``graph`` (BFS from a seed node id given as ``query_text``).
+``vector`` / ``hybrid`` remain unimplemented and are rejected at
+``is_valid_credentials`` time via ``SUPPORTED_VALUES`` on each concrete, so
+neither reader lies about what it honors.
 """

--- a/open_kgo/feature_groups/kg/agent_memory/graph_walk_memory.py
+++ b/open_kgo/feature_groups/kg/agent_memory/graph_walk_memory.py
@@ -1,0 +1,121 @@
+"""NetworkX-backed graph-walk agent memory store.
+
+Second concrete in the ``agent_memory`` family alongside ``NetworkxMemoryReader``
+(lexical search). This reader implements ``retrieval_mode=graph`` — the pure
+graph-walk retrieval branch the lexical concrete narrows away — by treating the
+``query_text`` as a seed node id and returning the memories reachable from it
+(BFS over the directed memory graph). It is the family's proof that the
+``retrieval_mode`` enum's ``graph`` value is real, and it adds no new dependency
+(NetworkX is already a family dependency).
+
+Memory data is loaded from a JSON file at ``locator`` (shape:
+``{user_id: {"nodes": [...], "edges": [...]}}``), the same shape the lexical
+concrete consumes. ``retrieval_mode`` is narrowed to ``graph`` and
+``pagination_style`` to ``none`` via ``SUPPORTED_VALUES``.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from typing import Any, ClassVar, Mapping
+
+import networkx as nx
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.agent_memory.base import (
+    AgentMemoryFeatureGroup,
+    AgentMemoryReader,
+)
+from open_kgo.feature_groups.kg.errors import FixtureLoadError, UnknownMemoryScopeError
+from open_kgo.feature_groups.kg.fixtures import load_json_fixture
+
+
+def _validate_user_data(connector_id: str, locator: str, user_id: str, user_data: Any) -> Mapping[str, Any]:
+    """Raise ``FixtureLoadError`` unless ``user_data`` matches the documented shape.
+
+    Kept local to this concrete (rather than imported from the lexical reader's
+    private module) so the two backends stay independent — the same
+    self-contained pattern the other families follow.
+    """
+    if not isinstance(user_data, dict):
+        raise FixtureLoadError(
+            connector_id, locator, f"entry for {user_id!r} must be an object, got {type(user_data).__name__}."
+        )
+    for key in ("nodes", "edges"):
+        if key not in user_data:
+            raise FixtureLoadError(connector_id, locator, f"entry for {user_id!r} is missing required key {key!r}.")
+        if not isinstance(user_data[key], list):
+            raise FixtureLoadError(
+                connector_id,
+                locator,
+                f"entry for {user_id!r} key {key!r} must be a list, got {type(user_data[key]).__name__}.",
+            )
+    return user_data
+
+
+def _build_memory_graph(user_data: Mapping[str, Any]) -> nx.MultiDiGraph:
+    """Build a directed memory graph from a single user's validated entry."""
+    g: nx.MultiDiGraph = nx.MultiDiGraph()
+    for node in user_data["nodes"]:
+        g.add_node(node["id"], **{k: v for k, v in node.items() if k != "id"})
+    for edge in user_data["edges"]:
+        g.add_edge(edge["src"], edge["tgt"], **{k: v for k, v in edge.items() if k not in {"src", "tgt"}})
+    return g
+
+
+class GraphWalkMemoryReader(AgentMemoryReader):
+    CONNECTOR_ID: ClassVar[str] = "graph_walk_memory"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (
+        ("locator",),
+        ("memory_scope_user_id",),
+    )
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "pagination_style": frozenset({"none"}),
+        "retrieval_mode": frozenset({"graph"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> nx.MultiDiGraph:
+        locator = str(slot["locator"])
+        store = load_json_fixture(cls.CONNECTOR_ID, locator)
+        user_id = str(slot["memory_scope_user_id"])
+        if user_id not in store:
+            raise UnknownMemoryScopeError(cls.CONNECTOR_ID, user_id)
+        user_data = _validate_user_data(cls.CONNECTOR_ID, locator, user_id, store[user_id])
+        return _build_memory_graph(user_data)
+
+    @classmethod
+    def build_query(cls, features: FeatureSet) -> str:
+        feature = next(iter(features.features))
+        text = feature.options.get("query_text")
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError(f"{cls.CONNECTOR_ID}: 'query_text' (the seed node id) is required.")
+        return text
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        graph = cls._connect_from_slot(ctx.slot)
+        seed = cls.build_query(features)
+
+        if seed not in graph:
+            return []
+
+        rows: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        queue: deque[str] = deque([seed])
+        # BFS over reachable memories; short-circuits at result_limit so the cap
+        # bounds the walk rather than slicing a fully-expanded reachable set.
+        while queue and len(rows) < ctx.result_limit:
+            node_id = queue.popleft()
+            if node_id in seen:
+                continue
+            seen.add(node_id)
+            rows.append({"id": node_id, **graph.nodes[node_id]})
+            queue.extend(successor for successor in graph.successors(node_id) if successor not in seen)
+        return rows
+
+
+class GraphWalkMemoryFeatureGroup(AgentMemoryFeatureGroup):
+    READER_CLASS: ClassVar[type[GraphWalkMemoryReader]] = GraphWalkMemoryReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/agent_memory/tests/fixtures/graph_memories.json
+++ b/open_kgo/feature_groups/kg/agent_memory/tests/fixtures/graph_memories.json
@@ -1,0 +1,14 @@
+{
+  "user_42": {
+    "nodes": [
+      {"id": "m1", "label": "likes coffee", "valid_at": "2026-01-01T00:00:00Z"},
+      {"id": "m2", "label": "prefers strong coffee", "valid_at": "2026-02-01T00:00:00Z"},
+      {"id": "m3", "label": "drinks espresso daily", "valid_at": "2026-03-01T00:00:00Z"},
+      {"id": "m4", "label": "unrelated note about tea", "valid_at": "2026-01-15T00:00:00Z"}
+    ],
+    "edges": [
+      {"src": "m1", "tgt": "m2", "relation": "refines"},
+      {"src": "m2", "tgt": "m3", "relation": "refines"}
+    ]
+  }
+}

--- a/open_kgo/feature_groups/kg/agent_memory/tests/test_graph_walk_memory.py
+++ b/open_kgo/feature_groups/kg/agent_memory/tests/test_graph_walk_memory.py
@@ -1,0 +1,91 @@
+"""Concrete tests for GraphWalkMemoryReader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.provider import HashableDict
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.agent_memory.graph_walk_memory import GraphWalkMemoryReader
+from open_kgo.feature_groups.kg.agent_memory.tests.kg_agent_memory_contract import (
+    AgentMemoryContractTestBase,
+)
+from open_kgo.feature_groups.kg.errors import InvalidCredentialShape, UnknownMemoryScopeError
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "graph_memories.json"
+
+
+class TestGraphWalkMemoryReader(AgentMemoryContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[GraphWalkMemoryReader]:
+        return GraphWalkMemoryReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "graph_walk_memory": {
+                "locator": str(_FIXTURE),
+                "memory_scope_user_id": "user_42",
+                "retrieval_mode": "graph",
+                "pagination_style": "none",
+                "result_limit": 100,
+                "threshold": 0.0,
+                "mmr_lambda": 0.5,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        return {
+            "graph_walk_memory": {
+                "locator": str(_FIXTURE),
+                "memory_scope_user_id": "user_42",
+                "retrieval_mode": "evil",
+            }
+        }
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "graph_walk_memory__from_seed",
+            options=Options(context={"query_text": "m1"}),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) >= 1 and "label" in result[0]
+
+    def test_graph_walk_reaches_transitive_memories(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("graph_walk_memory", self.valid_credentials()["graph_walk_memory"], feat)
+        assert {r["id"] for r in rows} == {"m1", "m2", "m3"}
+
+    def test_disconnected_seed_returns_only_itself(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature("graph_walk_memory__m4", options=Options(context={"query_text": "m4"}))
+        rows = run_query("graph_walk_memory", self.valid_credentials()["graph_walk_memory"], feat)
+        assert {r["id"] for r in rows} == {"m4"}
+
+    @pytest.mark.parametrize("mode", ["lexical", "vector", "hybrid"])
+    def test_unsupported_retrieval_modes_rejected_at_validate_time(self, mode: str) -> None:
+        slot = dict(self.valid_credentials()["graph_walk_memory"])
+        slot["retrieval_mode"] = mode
+        creds = HashableDict({"graph_walk_memory": slot})
+        assert GraphWalkMemoryReader.is_valid_credentials(creds) is False
+        with pytest.raises(InvalidCredentialShape):
+            GraphWalkMemoryReader._validate_shape(slot)
+
+    def test_unknown_user_id_raises_typed_error(self) -> None:
+        slot = dict(self.valid_credentials()["graph_walk_memory"])
+        slot["memory_scope_user_id"] = "user_does_not_exist"
+        creds = HashableDict({"graph_walk_memory": slot})
+        with pytest.raises(UnknownMemoryScopeError):
+            GraphWalkMemoryReader.connect(creds)

--- a/open_kgo/feature_groups/kg/citation_rest/__init__.py
+++ b/open_kgo/feature_groups/kg/citation_rest/__init__.py
@@ -5,9 +5,13 @@ hierarchy_depth traversal, and species/release version pinning. Inherits
 ``PaginationMixin``.
 
 PROTOTYPE NOTE: ``FileFixtureCitationReader`` reads ``locator``,
-``stable_id``, and ``hierarchy_depth`` at runtime. ``pagination_style``
-(strict-validated), ``page_size``, ``cursor_token``, ``entity_type``,
-``species_prefix``, and ``dataset_version`` are accepted at the property
-layer but never read — the catalog dict is loaded eagerly and ancestor
-walks are bounded by ``hierarchy_depth`` alone.
+``stable_id``, and ``hierarchy_depth`` at runtime; it drops ``pagination_style``
+/ ``page_size`` and strips ``cursor_token`` / ``entity_type``, so its ancestor
+walk is bounded by ``hierarchy_depth`` alone.
+
+SECOND CONCRETE: ``PaginatedCitationReader`` *honors* the dropped surface —
+cursor pagination (``pagination_style=cursor`` + ``page_size`` + per-call
+``cursor_token`` offsets) plus an ``entity_type`` filter over the citation
+graph it walks. ``species_prefix`` / ``dataset_version`` remain accepted but
+unused on both concretes.
 """

--- a/open_kgo/feature_groups/kg/citation_rest/paginated_citation.py
+++ b/open_kgo/feature_groups/kg/citation_rest/paginated_citation.py
@@ -1,0 +1,89 @@
+"""Paginated citation connector serving a canned citation graph.
+
+Second concrete in the ``citation_rest`` family alongside
+``FileFixtureCitationReader`` (single-shot Reactome ancestor walk). This reader
+*honors* the family surface the Reactome concrete drops/strips: cursor
+pagination (``pagination_style=cursor`` + ``page_size`` + per-call
+``cursor_token``) and the ``entity_type`` per-call filter. It models a
+citation-graph API (OpenCitations / Semantic Scholar shape) where a work cites
+other works via ``references``.
+
+Walk semantics: BFS the citation graph from ``stable_id`` out to
+``hierarchy_depth`` hops, optionally filter the collected works by
+``entity_type``, sort by ``stableId`` for a stable page order, then return the
+``page_size`` slice starting at the ``cursor_token`` offset (an opaque
+``"offset:<N>"`` token), capped at ``result_limit``. Parsed with stdlib JSON
+(no new dependency).
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.citation_rest.base import (
+    CitationRestFeatureGroup,
+    CitationRestReader,
+)
+from open_kgo.feature_groups.kg.fixtures import copy_cached_row, load_json_fixture
+from open_kgo.feature_groups.kg.mixins import parse_offset_cursor
+
+
+class PaginatedCitationReader(CitationRestReader):
+    CONNECTOR_ID: ClassVar[str] = "paginated_citation"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("locator",),)
+
+    # pagination_style is narrowed to the cursor style this reader implements;
+    # page_size, cursor_token, and entity_type are all RETAINED (the new surface
+    # this concrete honors, vs. the Reactome concrete which drops/strips them).
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "pagination_style": frozenset({"cursor"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> dict[str, Any]:
+        """Return the parsed citation catalog; mtime-cached. Shared, read-only."""
+        return load_json_fixture(cls.CONNECTOR_ID, slot["locator"])
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        catalog = cls._connect_from_slot(ctx.slot)
+        params = cls.build_params(features, ctx.slot)
+
+        stable_id = params.get("stable_id")
+        if stable_id is None:
+            raise ValueError(f"{cls.CONNECTOR_ID}: stable_id is required for citation lookup.")
+        depth = int(params.get("hierarchy_depth", 1))
+        entity_type = params.get("entity_type")
+        offset = parse_offset_cursor(cls.CONNECTOR_ID, params.get("cursor_token"))
+        page_size = int(ctx.slot.get("page_size", 100))
+
+        # BFS the citation graph from stable_id out to ``depth`` hops.
+        collected: list[str] = []
+        visited: set[str] = set()
+        queue: list[tuple[str, int]] = [(stable_id, 0)]
+        while queue:
+            node_id, hop = queue.pop(0)
+            if node_id in visited or node_id not in catalog:
+                continue
+            visited.add(node_id)
+            collected.append(node_id)
+            if hop < depth:
+                for ref_id in catalog[node_id].get("references", []):
+                    if ref_id not in visited:
+                        queue.append((ref_id, hop + 1))
+
+        # entity_type filter, then deterministic order for stable pagination.
+        if entity_type is not None:
+            collected = [cid for cid in collected if catalog[cid].get("entityType") == entity_type]
+        collected.sort()
+
+        # Cursor page slice, bounded by result_limit.
+        page_ids = collected[offset : offset + page_size]
+        return [copy_cached_row(catalog[cid]) for cid in page_ids[: ctx.result_limit]]
+
+
+class PaginatedCitationFeatureGroup(CitationRestFeatureGroup):
+    READER_CLASS: ClassVar[type[PaginatedCitationReader]] = PaginatedCitationReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/citation_rest/tests/fixtures/citations.json
+++ b/open_kgo/feature_groups/kg/citation_rest/tests/fixtures/citations.json
@@ -1,0 +1,7 @@
+{
+  "W1": {"stableId": "W1", "entityType": "article", "title": "Seminal work", "references": ["W2", "W3", "W4"]},
+  "W2": {"stableId": "W2", "entityType": "article", "title": "Follow-up", "references": ["W5"]},
+  "W3": {"stableId": "W3", "entityType": "book", "title": "Reference book", "references": []},
+  "W4": {"stableId": "W4", "entityType": "article", "title": "Related study", "references": []},
+  "W5": {"stableId": "W5", "entityType": "article", "title": "Foundational paper", "references": []}
+}

--- a/open_kgo/feature_groups/kg/citation_rest/tests/test_paginated_citation.py
+++ b/open_kgo/feature_groups/kg/citation_rest/tests/test_paginated_citation.py
@@ -1,0 +1,109 @@
+"""Concrete tests for PaginatedCitationReader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.provider import HashableDict
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.citation_rest.paginated_citation import (
+    PaginatedCitationReader,
+)
+from open_kgo.feature_groups.kg.citation_rest.tests.kg_citation_rest_contract import (
+    CitationRestContractTestBase,
+)
+from open_kgo.feature_groups.kg.errors import InvalidCredentialShape
+from open_kgo.feature_groups.kg.mixins import parse_offset_cursor
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "citations.json"
+
+
+class TestPaginatedCitationReader(CitationRestContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[PaginatedCitationReader]:
+        return PaginatedCitationReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "paginated_citation": {
+                "locator": str(_FIXTURE),
+                "pagination_style": "cursor",
+                "page_size": 2,
+                "species_prefix": "HSA",
+                "dataset_version": "v1",
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        # pagination_style="page" is in the family set but outside this
+        # concrete's SUPPORTED_VALUES narrowing ({"cursor"}), so it rejects.
+        return {"paginated_citation": {"locator": str(_FIXTURE), "pagination_style": "page"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "paginated_citation__page1",
+            options=Options(context={"stable_id": "W1", "hierarchy_depth": 3, "entity_type": "article"}),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) >= 1 and "stableId" in result[0]
+
+    def test_first_page_honors_page_size(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("paginated_citation", self.valid_credentials()["paginated_citation"], feat)
+        assert [r["stableId"] for r in rows] == ["W1", "W2"]
+
+    def test_second_page_via_cursor_token(self) -> None:
+        """A cursor_token offset returns the next page of the article-filtered walk."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "paginated_citation__page2",
+            options=Options(
+                context={
+                    "stable_id": "W1",
+                    "hierarchy_depth": 3,
+                    "entity_type": "article",
+                    "cursor_token": "offset:2",
+                }
+            ),
+        )
+        rows = run_query("paginated_citation", self.valid_credentials()["paginated_citation"], feat)
+        assert [r["stableId"] for r in rows] == ["W4", "W5"]
+
+    def test_entity_type_filter_selects_books(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "paginated_citation__books",
+            options=Options(context={"stable_id": "W1", "hierarchy_depth": 3, "entity_type": "book"}),
+        )
+        rows = run_query("paginated_citation", self.valid_credentials()["paginated_citation"], feat)
+        assert [r["stableId"] for r in rows] == ["W3"]
+
+    def test_malformed_cursor_token_rejected(self) -> None:
+        with pytest.raises(InvalidCredentialShape):
+            parse_offset_cursor("paginated_citation", "garbage")
+
+    def test_none_cursor_is_first_page(self) -> None:
+        assert parse_offset_cursor("paginated_citation", None) == 0
+
+    def test_cursor_token_requires_cursor_family_style(self) -> None:
+        """The PaginationMixin cross-layer guard fires: cursor_token only valid with a cursor style."""
+        slot = dict(self.valid_credentials()["paginated_citation"])
+        creds = HashableDict({"paginated_citation": slot})
+        # is_valid_credentials only checks the credential surface; the cross-layer
+        # check runs in build_params, so the credential slot itself stays valid.
+        assert PaginatedCitationReader.is_valid_credentials(creds) is True

--- a/open_kgo/feature_groups/kg/code_build/__init__.py
+++ b/open_kgo/feature_groups/kg/code_build/__init__.py
@@ -5,11 +5,14 @@ includes ``commit_sha``, ``branch``, ``language_code``. Inherits ``TraversalMixi
 
 PROTOTYPE NOTE: ``CycloneDxSbomReader`` reads ``manifest_path`` (with
 ``locator`` fallback) and returns the SBOM's ``components`` list — nothing
-more. The entire ``TraversalMixin`` surface (``lineage_direction``,
-``upstream_depth``, ``downstream_depth``, ``entity_type``,
-``relationship_type``, ``expand_paths``) is accepted at the property layer
-and ignored at runtime. The CycloneDX ``dependencies`` array, which carries
-the actual build-graph edges, is **not walked** — so the family inherits a
-traversal mixin it does not exercise. ``commit_sha``, ``branch``, and
-``language_code`` are also accepted but unused.
+more. It strips the entire ``TraversalMixin`` / ``EntityFilter`` per-call
+surface (rejected via ``_STRIPPED_PARAMS``); the CycloneDX ``dependencies``
+array is **not walked**. ``commit_sha``, ``branch``, and ``language_code``
+are accepted but unused.
+
+SECOND CONCRETE: ``SpdxSbomReader`` *does* walk the dependency graph. It
+parses the SPDX ``relationships`` array (``DEPENDS_ON`` / ``DEPENDENCY_OF``)
+and honors the family's ``TraversalMixin`` keys (``lineage_direction``,
+``upstream_depth``, ``downstream_depth``) by BFS from a ``start_spdx_id``,
+so the family no longer inherits a traversal mixin that nothing exercises.
 """

--- a/open_kgo/feature_groups/kg/code_build/spdx_sbom.py
+++ b/open_kgo/feature_groups/kg/code_build/spdx_sbom.py
@@ -1,0 +1,178 @@
+"""SPDX SBOM parser as a code_build source, walking the dependency graph.
+
+Second concrete in the ``code_build`` family alongside ``CycloneDxSbomReader``.
+SPDX is the other major SBOM standard; its JSON form carries ``packages`` and a
+``relationships`` array whose ``DEPENDS_ON`` / ``DEPENDENCY_OF`` edges form a
+real dependency graph. Where the CycloneDX concrete returns a flat component
+list and strips every traversal key, this concrete *honors* the family's
+``TraversalMixin`` per-call keys (``lineage_direction``, ``upstream_depth``,
+``downstream_depth``) by BFS-walking that graph from a starting package. It is
+the family's proof that the declared traversal surface is real, not decorative.
+
+Parsed with stdlib JSON (no new dependency), mirroring the CycloneDX concrete.
+The start package is named by a concrete-local ``start_spdx_id`` per-call param
+(the code_build family base has no start-node key, unlike lineage's
+``asset_urn``); the family-level entity-filter keys (``entity_type``,
+``relationship_type``, ``expand_paths``) are dropped and rejected per-call.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, ClassVar, Mapping
+
+from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.base import compose_property_mapping
+from open_kgo.feature_groups.kg.code_build.base import (
+    CodeBuildFeatureGroup,
+    CodeBuildReader,
+)
+from open_kgo.feature_groups.kg.fixtures import copy_cached_row, load_json_fixture
+from open_kgo.feature_groups.kg.mixins import TraversalMixin
+
+
+def _build_dependency_maps(
+    relationships: list[Any],
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
+    """Return ``(upstream_map, downstream_map)`` from SPDX relationship records.
+
+    ``upstream_map[p]`` lists the packages ``p`` depends on (its dependencies);
+    ``downstream_map[p]`` lists the packages that depend on ``p`` (its
+    dependents). Both ``DEPENDS_ON`` (``A`` depends on ``B``) and its inverse
+    ``DEPENDENCY_OF`` (``B`` is a dependency of ``A``) are normalised to the
+    same ``depender -> dependency`` orientation; every other relationship type
+    (``CONTAINS``, ``DESCRIBES``, ...) is ignored. Malformed records missing
+    either endpoint are skipped defensively.
+    """
+    upstream: dict[str, list[str]] = defaultdict(list)
+    downstream: dict[str, list[str]] = defaultdict(list)
+    for rel in relationships:
+        if not isinstance(rel, dict):
+            continue
+        rtype = rel.get("relationshipType")
+        if rtype == "DEPENDS_ON":
+            depender, dependency = rel.get("spdxElementId"), rel.get("relatedSpdxElement")
+        elif rtype == "DEPENDENCY_OF":
+            depender, dependency = rel.get("relatedSpdxElement"), rel.get("spdxElementId")
+        else:
+            continue
+        if not depender or not dependency:
+            continue
+        upstream[depender].append(dependency)
+        downstream[dependency].append(depender)
+    return dict(upstream), dict(downstream)
+
+
+def _walk_packages(
+    edge_map: dict[str, list[str]],
+    packages_index: dict[str, Any],
+    start: str,
+    depth: int,
+    remaining: int,
+) -> list[dict[str, Any]]:
+    """BFS along ``edge_map`` from ``start`` up to ``depth`` hops; emit package rows.
+
+    Aborts once ``remaining`` rows have been emitted so ``result_limit`` bounds
+    the work walked, not just the output sliced (mirrors the lineage readers).
+    Packages are routed through ``copy_cached_row`` so the shared cached SBOM
+    stays read-only when a row escapes to a caller.
+    """
+    if depth <= 0 or remaining <= 0:
+        return []
+    out: list[dict[str, Any]] = []
+    seen: set[str] = {start}
+    frontier: list[str] = [start]
+    for _ in range(depth):
+        next_frontier: list[str] = []
+        for node in frontier:
+            for neighbour in edge_map.get(node, []):
+                if neighbour in seen:
+                    continue
+                seen.add(neighbour)
+                if neighbour in packages_index:
+                    out.append(copy_cached_row(packages_index[neighbour]))
+                    if len(out) >= remaining:
+                        return out
+                next_frontier.append(neighbour)
+        if not next_frontier:
+            break
+        frontier = next_frontier
+    return out
+
+
+class SpdxSbomReader(CodeBuildReader):
+    CONNECTOR_ID: ClassVar[str] = "spdx_sbom"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("manifest_path", "locator"),)
+
+    # Keep the TraversalMixin per-call keys (this concrete honors them) and add
+    # a concrete-local start-node key; drop the EntityFilterParamMixin keys
+    # (entity_type / relationship_type / expand_paths), which the framework then
+    # rejects per-call via ``_STRIPPED_PARAMS``.
+    PARAMS_MAPPING: ClassVar[dict[str, Any]] = compose_property_mapping(
+        TraversalMixin.PARAMS_MAPPING_DELTA,
+        {
+            "start_spdx_id": {
+                "explanation": "SPDXID of the package to start the dependency walk from.",
+                DefaultOptionKeys.context: True,
+                DefaultOptionKeys.strict_validation: False,
+                DefaultOptionKeys.default: None,
+            },
+        },
+        context="SpdxSbomReader.PARAMS_MAPPING",
+    )
+    REQUIRED_PARAMS: ClassVar[tuple[tuple[str, ...], ...]] = (("start_spdx_id",),)
+
+    # SPDX relationships are a dependency graph, so the walker dispatches on
+    # UPSTREAM / DOWNSTREAM / BOTH only; the family enum's Reactome-style
+    # ancestors / descendants are not applicable here.
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "lineage_direction": frozenset({"UPSTREAM", "DOWNSTREAM", "BOTH"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> dict[str, Any]:
+        """Return the parsed SPDX dict; mtime-cached so repeated loads skip the JSON parse.
+
+        Returned dict is shared across calls and MUST be treated as read-only;
+        ``load_data`` routes each emitted package through ``copy_cached_row``.
+        """
+        manifest_path = slot.get("manifest_path") or slot.get("locator")
+        return load_json_fixture(cls.CONNECTOR_ID, manifest_path)
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        sbom = cls._connect_from_slot(ctx.slot)
+        params = cls.build_params(features, ctx.slot)
+
+        start = params.get("start_spdx_id")
+        if not start:
+            raise ValueError(f"{cls.CONNECTOR_ID}: 'start_spdx_id' is required.")
+        direction = params.get("lineage_direction", "BOTH")
+        upstream_depth = int(params.get("upstream_depth", 1))
+        downstream_depth = int(params.get("downstream_depth", 0))
+        result_limit = ctx.result_limit
+
+        packages_index = {
+            pkg["SPDXID"]: pkg for pkg in sbom.get("packages", []) if isinstance(pkg, dict) and "SPDXID" in pkg
+        }
+        upstream_map, downstream_map = _build_dependency_maps(sbom.get("relationships", []))
+
+        rows: list[dict[str, Any]] = []
+        if start in packages_index and result_limit > 0:
+            rows.append(copy_cached_row(packages_index[start]))
+
+        if direction in ("UPSTREAM", "BOTH") and len(rows) < result_limit:
+            rows.extend(_walk_packages(upstream_map, packages_index, start, upstream_depth, result_limit - len(rows)))
+        if direction in ("DOWNSTREAM", "BOTH") and len(rows) < result_limit:
+            rows.extend(
+                _walk_packages(downstream_map, packages_index, start, downstream_depth, result_limit - len(rows))
+            )
+
+        return rows
+
+
+class SpdxSbomFeatureGroup(CodeBuildFeatureGroup):
+    READER_CLASS: ClassVar[type[SpdxSbomReader]] = SpdxSbomReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/code_build/tests/fixtures/sample.spdx.json
+++ b/open_kgo/feature_groups/kg/code_build/tests/fixtures/sample.spdx.json
@@ -1,0 +1,18 @@
+{
+  "spdxVersion": "SPDX-2.3",
+  "dataLicense": "CC0-1.0",
+  "SPDXID": "SPDXRef-DOCUMENT",
+  "name": "example-app-sbom",
+  "packages": [
+    {"SPDXID": "SPDXRef-Package-app", "name": "app", "versionInfo": "1.0.0"},
+    {"SPDXID": "SPDXRef-Package-flask", "name": "flask", "versionInfo": "3.0.0"},
+    {"SPDXID": "SPDXRef-Package-werkzeug", "name": "werkzeug", "versionInfo": "3.0.1"},
+    {"SPDXID": "SPDXRef-Package-click", "name": "click", "versionInfo": "8.1.7"}
+  ],
+  "relationships": [
+    {"spdxElementId": "SPDXRef-DOCUMENT", "relatedSpdxElement": "SPDXRef-Package-app", "relationshipType": "DESCRIBES"},
+    {"spdxElementId": "SPDXRef-Package-app", "relatedSpdxElement": "SPDXRef-Package-flask", "relationshipType": "DEPENDS_ON"},
+    {"spdxElementId": "SPDXRef-Package-flask", "relatedSpdxElement": "SPDXRef-Package-werkzeug", "relationshipType": "DEPENDS_ON"},
+    {"spdxElementId": "SPDXRef-Package-flask", "relatedSpdxElement": "SPDXRef-Package-click", "relationshipType": "DEPENDS_ON"}
+  ]
+}

--- a/open_kgo/feature_groups/kg/code_build/tests/fixtures/sample.spdx.json
+++ b/open_kgo/feature_groups/kg/code_build/tests/fixtures/sample.spdx.json
@@ -7,12 +7,16 @@
     {"SPDXID": "SPDXRef-Package-app", "name": "app", "versionInfo": "1.0.0"},
     {"SPDXID": "SPDXRef-Package-flask", "name": "flask", "versionInfo": "3.0.0"},
     {"SPDXID": "SPDXRef-Package-werkzeug", "name": "werkzeug", "versionInfo": "3.0.1"},
-    {"SPDXID": "SPDXRef-Package-click", "name": "click", "versionInfo": "8.1.7"}
+    {"SPDXID": "SPDXRef-Package-click", "name": "click", "versionInfo": "8.1.7"},
+    {"SPDXID": "SPDXRef-Package-lib-a", "name": "lib-a", "versionInfo": "2.0.0"},
+    {"SPDXID": "SPDXRef-Package-lib-b", "name": "lib-b", "versionInfo": "2.1.0"}
   ],
   "relationships": [
     {"spdxElementId": "SPDXRef-DOCUMENT", "relatedSpdxElement": "SPDXRef-Package-app", "relationshipType": "DESCRIBES"},
     {"spdxElementId": "SPDXRef-Package-app", "relatedSpdxElement": "SPDXRef-Package-flask", "relationshipType": "DEPENDS_ON"},
     {"spdxElementId": "SPDXRef-Package-flask", "relatedSpdxElement": "SPDXRef-Package-werkzeug", "relationshipType": "DEPENDS_ON"},
-    {"spdxElementId": "SPDXRef-Package-flask", "relatedSpdxElement": "SPDXRef-Package-click", "relationshipType": "DEPENDS_ON"}
+    {"spdxElementId": "SPDXRef-Package-flask", "relatedSpdxElement": "SPDXRef-Package-click", "relationshipType": "DEPENDS_ON"},
+    {"spdxElementId": "SPDXRef-Package-lib-b", "relatedSpdxElement": "SPDXRef-Package-lib-a", "relationshipType": "DEPENDENCY_OF"},
+    {"spdxElementId": "SPDXRef-Package-lib-a", "relatedSpdxElement": "SPDXRef-Package-does-not-exist", "relationshipType": "DEPENDS_ON"}
   ]
 }

--- a/open_kgo/feature_groups/kg/code_build/tests/test_spdx_sbom.py
+++ b/open_kgo/feature_groups/kg/code_build/tests/test_spdx_sbom.py
@@ -91,6 +91,31 @@ class TestSpdxSbomReader(CodeBuildContractTestBase):
         rows = run_query("spdx_sbom", self.valid_credentials()["spdx_sbom"], feat)
         assert {r["name"] for r in rows} == {"app", "flask"}
 
+    def test_dependency_of_inverse_orientation_and_dangling_edge(self) -> None:
+        """``DEPENDENCY_OF`` resolves to the same depender->dependency orientation, and a
+        relationship pointing at a package id absent from ``packages`` is skipped
+        without aborting the walk.
+
+        Fixture: ``lib-b DEPENDENCY_OF lib-a`` (so lib-a depends on lib-b) plus a
+        dangling ``lib-a DEPENDS_ON <missing>``. Walking UPSTREAM from lib-a must
+        reach lib-b (inverse orientation) and drop the missing id from output.
+        """
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "spdx_sbom__lib_upstream",
+            options=Options(
+                context={
+                    "start_spdx_id": "SPDXRef-Package-lib-a",
+                    "lineage_direction": "UPSTREAM",
+                    "upstream_depth": 2,
+                    "downstream_depth": 0,
+                }
+            ),
+        )
+        rows = run_query("spdx_sbom", self.valid_credentials()["spdx_sbom"], feat)
+        assert {r["name"] for r in rows} == {"lib-a", "lib-b"}
+
     def test_downstream_walk_finds_dependents(self) -> None:
         from open_kgo.feature_groups.kg.tests._helpers import run_query
 

--- a/open_kgo/feature_groups/kg/code_build/tests/test_spdx_sbom.py
+++ b/open_kgo/feature_groups/kg/code_build/tests/test_spdx_sbom.py
@@ -1,0 +1,109 @@
+"""Concrete tests for SpdxSbomReader.
+
+Unlike the CycloneDX concrete (flat component list), this reader walks the
+SPDX ``DEPENDS_ON`` graph, so the tests assert the family's TraversalMixin
+keys (``lineage_direction`` / ``upstream_depth`` / ``downstream_depth``) are
+honored end to end.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.code_build.spdx_sbom import SpdxSbomReader
+from open_kgo.feature_groups.kg.code_build.tests.kg_code_build_contract import (
+    CodeBuildContractTestBase,
+)
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "sample.spdx.json"
+
+
+class TestSpdxSbomReader(CodeBuildContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[SpdxSbomReader]:
+        return SpdxSbomReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        # REQUIRED_KEYS lists manifest_path / locator as alternatives; the
+        # per-alternative coherence contract requires every alternative present.
+        return {
+            "spdx_sbom": {
+                "manifest_path": str(_FIXTURE),
+                "locator": str(_FIXTURE),
+                "commit_sha": "a1b2c3d4",
+                "branch": "main",
+                "language_code": "python",
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        # No strict-validation credential enum on this concrete; trigger the
+        # closed-world unknown-key rejection.
+        return {"spdx_sbom": {"manifest_path": str(_FIXTURE), "definitely_not_a_kg_key": "x"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "spdx_sbom__upstream",
+            options=Options(
+                context={
+                    "start_spdx_id": "SPDXRef-Package-app",
+                    "lineage_direction": "UPSTREAM",
+                    "upstream_depth": 2,
+                    "downstream_depth": 0,
+                }
+            ),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) >= 1 and "name" in result[0]
+
+    def test_upstream_walk_reaches_transitive_dependencies(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("spdx_sbom", self.valid_credentials()["spdx_sbom"], feat)
+        assert {r["name"] for r in rows} == {"app", "flask", "werkzeug", "click"}
+
+    def test_depth_one_excludes_transitive(self) -> None:
+        """upstream_depth=1 stops at flask; werkzeug/click are two hops out."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "spdx_sbom__upstream_d1",
+            options=Options(
+                context={
+                    "start_spdx_id": "SPDXRef-Package-app",
+                    "lineage_direction": "UPSTREAM",
+                    "upstream_depth": 1,
+                    "downstream_depth": 0,
+                }
+            ),
+        )
+        rows = run_query("spdx_sbom", self.valid_credentials()["spdx_sbom"], feat)
+        assert {r["name"] for r in rows} == {"app", "flask"}
+
+    def test_downstream_walk_finds_dependents(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "spdx_sbom__downstream",
+            options=Options(
+                context={
+                    "start_spdx_id": "SPDXRef-Package-flask",
+                    "lineage_direction": "DOWNSTREAM",
+                    "upstream_depth": 0,
+                    "downstream_depth": 1,
+                }
+            ),
+        )
+        rows = run_query("spdx_sbom", self.valid_credentials()["spdx_sbom"], feat)
+        assert {r["name"] for r in rows} == {"flask", "app"}

--- a/open_kgo/feature_groups/kg/conftest.py
+++ b/open_kgo/feature_groups/kg/conftest.py
@@ -30,6 +30,7 @@ import pytest
 from open_kgo.feature_groups.kg.fixtures import (
     _open_kuzu_database_cached,
     _read_json_cached,
+    _read_oxigraph_store_cached,
     _read_rdf_graph_cached,
 )
 from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
@@ -40,10 +41,12 @@ def _clear_kg_resource_caches() -> Any:
     """Clear every resource cache before and after each KG test."""
     _read_json_cached.cache_clear()
     _read_rdf_graph_cached.cache_clear()
+    _read_oxigraph_store_cached.cache_clear()
     _open_kuzu_database_cached.cache_clear()
     OntologyRegistry._clear()
     yield
     _read_json_cached.cache_clear()
     _read_rdf_graph_cached.cache_clear()
+    _read_oxigraph_store_cached.cache_clear()
     _open_kuzu_database_cached.cache_clear()
     OntologyRegistry._clear()

--- a/open_kgo/feature_groups/kg/embedded/__init__.py
+++ b/open_kgo/feature_groups/kg/embedded/__init__.py
@@ -6,8 +6,10 @@ the embedded family has no network endpoint). The family base declares
 already in memory) are valid; concrete plugins set ``REQUIRED_KEYS``
 explicitly when their backend needs a path.
 
-PROTOTYPE NOTE: ``read_only`` and ``max_threads`` are advisory-only. The
-concrete ``NetworkxEmbeddedReader`` validates them at the property layer
-but never enforces them at runtime; NetworkX has no read-only mode and
-the reader is single-threaded.
+PROTOTYPE NOTE: two in-memory graph libraries back this family —
+``NetworkxEmbeddedReader`` (``networkx``) and ``IGraphEmbeddedReader``
+(``igraph``) — running the same ``nodes`` / ``edges`` / ``neighbors``
+operations against the same committed GML fixtures (backend variety, not new
+surface). ``read_only`` and ``max_threads`` are advisory-only on both: they
+are validated at the property layer but never enforced at runtime.
 """

--- a/open_kgo/feature_groups/kg/embedded/igraph_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/igraph_embedded.py
@@ -1,0 +1,119 @@
+"""python-igraph-backed embedded graph reader.
+
+Second concrete in the ``embedded`` family alongside ``NetworkxEmbeddedReader``:
+loads a graph from a fixture file (.gml / .graphml / .edgelist) at ``locator``
+via python-igraph and runs the same family operations (``nodes`` / ``edges`` /
+``neighbors``). Demonstrates that the embedded family base generalises across a
+second in-memory graph library; no new family surface is unlocked (igraph,
+like NetworkX, is an embedded in-process backend), so this is backend variety,
+not a new contract branch.
+
+The vertex identity exposed in rows is the first present of ``name`` / ``label``
+/ ``id``, falling back to the integer vertex index. The committed GML fixtures
+carry a ``label`` per node, so rows key on the label (e.g. ``"alice"``), which
+mirrors what ``nx.read_gml`` produces (it relabels nodes to their ``label``).
+"""
+
+from __future__ import annotations
+
+from itertools import islice
+from typing import Any, ClassVar, Mapping
+
+import igraph
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.embedded.base import (
+    EmbeddedGraphFeatureGroup,
+    EmbeddedGraphReader,
+)
+from open_kgo.feature_groups.kg.fixtures import _rejected_scheme
+
+
+_LOADERS: dict[str, Any] = {
+    "gml": igraph.Graph.Read_GML,
+    "graphml": igraph.Graph.Read_GraphML,
+    "edgelist": igraph.Graph.Read_Edgelist,
+}
+
+
+def _vertex_key(vertex: igraph.Vertex) -> Any:
+    """Return a stable identifier for ``vertex``: first present of name/label/id, else index.
+
+    igraph vertices are integer-indexed; GML/GraphML readers surface the
+    source identifiers as the ``name`` / ``label`` / ``id`` attributes. The
+    NetworkX reader keys rows on the node id (its GML loader relabels nodes to
+    their ``label``), so preferring ``name`` then ``label`` keeps the two
+    embedded backends' row shapes aligned on the same committed fixtures. The
+    integer-index fallback covers plain edge lists, whose vertices carry no
+    attributes.
+    """
+    attrs = vertex.attributes()
+    for attr in ("name", "label", "id"):
+        value = attrs.get(attr)
+        if value is not None:
+            return value
+    return vertex.index
+
+
+class IGraphEmbeddedReader(EmbeddedGraphReader):
+    CONNECTOR_ID: ClassVar[str] = "igraph_embedded"
+    # Strict-enum dispositions mirror NetworkxEmbeddedReader: every
+    # family-advertised graph_file_format is wired into ``_LOADERS`` and every
+    # operation is dispatched in ``load_data``. Mirroring the full family set
+    # (rather than leaving it implicit) makes a future family-level addition
+    # surface here as a contract failure instead of a silent drop.
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "graph_file_format": frozenset({"gml", "graphml", "edgelist"}),
+        "operation": frozenset({"nodes", "edges", "neighbors"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> igraph.Graph:
+        locator = slot.get("locator")
+        if not locator:
+            return igraph.Graph()
+        # Reject remote locators for parity with the other file-backed readers;
+        # igraph's loaders only open local paths, so this keeps the file-only
+        # contract uniform across families.
+        bad = _rejected_scheme(locator)
+        if bad is not None:
+            raise ValueError(
+                f"{cls.CONNECTOR_ID}: locator scheme {bad!r} is not permitted; "
+                f"only local file paths or file:// URLs are allowed."
+            )
+        fmt = slot.get("graph_file_format", "gml")
+        loader = _LOADERS.get(fmt)
+        if loader is None:
+            raise ValueError(f"{cls.CONNECTOR_ID}: unsupported graph_file_format={fmt!r}")
+        return loader(str(locator))
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        graph = cls._connect_from_slot(ctx.slot)
+
+        params = cls.build_params(features, ctx.slot)
+        op = params["operation"]
+
+        if op == "nodes":
+            return [{"node": _vertex_key(v)} for v in islice(graph.vs, ctx.result_limit)]
+        if op == "edges":
+            return [
+                {"src": _vertex_key(graph.vs[e.source]), "dst": _vertex_key(graph.vs[e.target])}
+                for e in islice(graph.es, ctx.result_limit)
+            ]
+        if op == "neighbors":
+            start = params.get("start_node")
+            if start is None:
+                raise ValueError(f"{cls.CONNECTOR_ID}: operation=neighbors requires 'start_node'.")
+            start_indices = [v.index for v in graph.vs if _vertex_key(v) == start]
+            if not start_indices:
+                return []
+            neighbors = islice(graph.neighbors(start_indices[0]), ctx.result_limit)
+            return [{"node": _vertex_key(graph.vs[n])} for n in neighbors]
+        raise ValueError(f"{cls.CONNECTOR_ID}: unsupported operation={op!r}")
+
+
+class IGraphEmbeddedFeatureGroup(EmbeddedGraphFeatureGroup):
+    READER_CLASS: ClassVar[type[IGraphEmbeddedReader]] = IGraphEmbeddedReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/embedded/igraph_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/igraph_embedded.py
@@ -110,7 +110,11 @@ class IGraphEmbeddedReader(EmbeddedGraphReader):
             start_indices = [v.index for v in graph.vs if _vertex_key(v) == start]
             if not start_indices:
                 return []
-            neighbors = islice(graph.neighbors(start_indices[0]), ctx.result_limit)
+            # ``mode="out"`` matches NetworkxEmbeddedReader, which uses
+            # ``DiGraph.neighbors`` (successors). On an undirected graph igraph
+            # ignores ``mode`` and returns all neighbors, so the two embedded
+            # backends agree on both directed and undirected inputs.
+            neighbors = islice(graph.neighbors(start_indices[0], mode="out"), ctx.result_limit)
             return [{"node": _vertex_key(graph.vs[n])} for n in neighbors]
         raise ValueError(f"{cls.CONNECTOR_ID}: unsupported operation={op!r}")
 

--- a/open_kgo/feature_groups/kg/embedded/tests/test_igraph_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/tests/test_igraph_embedded.py
@@ -1,0 +1,85 @@
+"""Concrete tests for IGraphEmbeddedReader.
+
+Reuses the committed ``triangle.gml`` fixture (shared with the NetworkX
+embedded reader) so both embedded backends are asserted against the same
+graph, demonstrating the family base generalises across libraries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.embedded.igraph_embedded import IGraphEmbeddedReader
+from open_kgo.feature_groups.kg.embedded.tests.kg_embedded_contract import (
+    EmbeddedContractTestBase,
+)
+
+
+_FIXTURE_GML = Path(__file__).parent / "fixtures" / "triangle.gml"
+
+
+class TestIGraphEmbeddedReader(EmbeddedContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[IGraphEmbeddedReader]:
+        return IGraphEmbeddedReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "igraph_embedded": {
+                "locator": str(_FIXTURE_GML),
+                "graph_file_format": "gml",
+                "read_only": True,
+                "max_threads": 1,
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        return {
+            "igraph_embedded": {
+                "locator": str(_FIXTURE_GML),
+                "graph_file_format": "evil_format",
+            }
+        }
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "igraph_embedded__nodes",
+            options=Options(context={"operation": "nodes"}),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) > 0
+
+    def test_nodes_operation_returns_three_labels(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("igraph_embedded", self.valid_credentials()["igraph_embedded"], feat)
+        assert sorted(r["node"] for r in rows) == ["alice", "bob", "carol"]
+
+    def test_neighbors_operation(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "igraph_embedded__neighbors",
+            options=Options(context={"operation": "neighbors", "start_node": "alice"}),
+        )
+        rows = run_query("igraph_embedded", self.valid_credentials()["igraph_embedded"], feat)
+        assert sorted(r["node"] for r in rows) == ["bob", "carol"]
+
+    def test_http_locator_rejected(self) -> None:
+        """Remote schemes must be refused, like the other file-backed readers."""
+        cls = self.connector_reader_class()
+        creds = {cls.CONNECTOR_ID: {"locator": "http://example.com/evil.gml"}}
+        with pytest.raises(ValueError, match="scheme"):
+            cls.connect(creds)

--- a/open_kgo/feature_groups/kg/fixtures.py
+++ b/open_kgo/feature_groups/kg/fixtures.py
@@ -217,6 +217,70 @@ def _read_rdf_graph_cached(abs_path: str, mtime_ns: int) -> rdflib.Graph:
     return graph
 
 
+_OXIGRAPH_FORMAT_BY_SUFFIX: dict[str, str] = {
+    ".ttl": "TURTLE",
+    ".nt": "N_TRIPLES",
+    ".n3": "N3",
+    ".trig": "TRIG",
+    ".nq": "N_QUADS",
+    ".rdf": "RDF_XML",
+    ".xml": "RDF_XML",
+    ".jsonld": "JSON_LD",
+}
+
+
+def load_oxigraph_store(connector_id: str, locator: Any) -> Any:
+    """Parse an RDF file into an in-memory ``pyoxigraph.Store``; memoised by ``(path, mtime_ns)``.
+
+    The oxigraph sibling of ``load_rdf_graph``: a real Turtle file is
+    1-100MB and oxigraph's parse pass is the expensive step, so a
+    100-feature ``mloda.run_all`` pays one parse instead of one hundred.
+    Returns ``Any`` to keep the pyoxigraph dependency optional at import
+    time (the import is deferred to call time, mirroring
+    ``load_kuzu_database``), so test environments without the ``kg-rdf``
+    extra can still import this module. The returned store is shared
+    across calls; callers run read-only SPARQL queries against it and MUST
+    NOT mutate it.
+    """
+    path = _validate_local_locator(connector_id, locator)
+    locator_str = str(locator)
+    try:
+        mtime_ns = path.stat().st_mtime_ns
+    except OSError as exc:
+        raise FixtureLoadError(connector_id, locator_str, f"cannot stat locator path: {exc}") from exc
+    abs_path = str(path.resolve())
+    try:
+        return _read_oxigraph_store_cached(abs_path, mtime_ns)
+    except _FixtureLoadProblem as exc:
+        raise FixtureLoadError(connector_id, abs_path, exc.reason) from exc.__cause__
+
+
+@lru_cache(maxsize=64)
+def _read_oxigraph_store_cached(abs_path: str, mtime_ns: int) -> Any:
+    """Load ``abs_path`` into a ``pyoxigraph.Store``; memoised by ``(path, mtime_ns)``.
+
+    The RDF serialisation format is selected from the file extension
+    (defaulting to Turtle) since oxigraph's loader needs it explicitly,
+    unlike rdflib's content auto-detection. pyoxigraph raises the builtin
+    ``SyntaxError`` on malformed RDF (verified against pyoxigraph 0.5.x);
+    ``ValueError`` / ``UnicodeDecodeError`` cover bad bytes. The pyoxigraph
+    import is deferred so the module imports without the ``kg-rdf`` extra.
+    """
+    import pyoxigraph
+
+    fmt_name = _OXIGRAPH_FORMAT_BY_SUFFIX.get(Path(abs_path).suffix.lower(), "TURTLE")
+    rdf_format = getattr(pyoxigraph.RdfFormat, fmt_name)
+    store = pyoxigraph.Store()
+    try:
+        with open(abs_path, "rb") as f:
+            store.load(f.read(), format=rdf_format)
+    except OSError as exc:
+        raise _FixtureLoadProblem(f"cannot open RDF locator file: {exc}") from exc
+    except (SyntaxError, ValueError, UnicodeDecodeError) as exc:
+        raise _FixtureLoadProblem(f"locator is not parseable as RDF: {exc}") from exc
+    return store
+
+
 def load_kuzu_database(connector_id: str, locator: Any) -> Any:
     """Open a ``kuzu.Database`` for ``locator`` and cache the handle by path.
 

--- a/open_kgo/feature_groups/kg/lineage/__init__.py
+++ b/open_kgo/feature_groups/kg/lineage/__init__.py
@@ -4,10 +4,13 @@ Hidden-KG family. Locator points at a metadata service or file artifact;
 ``asset_urn`` is the addressing key, ``lineage_direction`` and depth properties
 come from ``TraversalMixin``.
 
-PROTOTYPE NOTE: ``DbtManifestReader`` is the deepest exerciser of
-``TraversalMixin`` (honors ``lineage_direction`` + ``upstream_depth`` +
-``downstream_depth``), but ``entity_type``, ``relationship_type``, and
-``expand_paths`` are accepted at the property layer and never read at
-runtime — the manifest walk is type-agnostic and follows every edge in
-``parent_map`` / ``child_map`` regardless of these filters.
+PROTOTYPE NOTE: ``DbtManifestReader`` honors ``lineage_direction`` +
+``upstream_depth`` + ``downstream_depth`` (walking ``parent_map`` /
+``child_map``); ``entity_type``, ``relationship_type``, and ``expand_paths``
+are accepted but never read (the walk is type-agnostic).
+
+SECOND CONCRETE: ``OpenLineageReader`` walks the dataset input/output graph
+derived from OpenLineage run-event JSON, honoring the same UPSTREAM /
+DOWNSTREAM / BOTH directions — a second real lineage artifact on the family
+base (backend variety, not new surface), with zero new dependency.
 """

--- a/open_kgo/feature_groups/kg/lineage/openlineage_events.py
+++ b/open_kgo/feature_groups/kg/lineage/openlineage_events.py
@@ -1,0 +1,145 @@
+"""OpenLineage run-event parser as a lineage source.
+
+Second concrete in the ``lineage`` family alongside ``DbtManifestReader``.
+OpenLineage is an open standard whose run events are emitted as JSON; each
+event names a ``job`` plus its ``inputs`` and ``outputs`` datasets. A dataset
+edge ``input -> output`` is derived per event (every input is upstream of every
+output of the same run), yielding a dataset-level lineage graph we walk from a
+starting ``asset_urn``. Like dbt, this is a static-artifact source (stdlib JSON,
+no new dependency); it adds backend/pedigree variety on the family's
+UPSTREAM / DOWNSTREAM / BOTH walk rather than a new family surface.
+
+The fixture top level is an object ``{"events": [<run event>, ...]}`` (the
+``load_json_fixture`` contract requires a dict at the top level; a bare event
+array would be rejected). Datasets are identified by their ``name`` field;
+``namespace`` is carried through into each row.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.fixtures import load_json_fixture
+from open_kgo.feature_groups.kg.lineage.base import LineageFeatureGroup, LineageReader
+
+
+def _build_dataset_graph(
+    events: list[Any],
+) -> tuple[dict[str, set[str]], dict[str, set[str]], dict[str, str]]:
+    """Return ``(upstream_map, downstream_map, namespace_index)`` from OpenLineage events.
+
+    ``upstream_map[ds]`` is the set of datasets ``ds`` was produced from
+    (parents); ``downstream_map[ds]`` is the set of datasets produced from
+    ``ds`` (children). ``namespace_index`` records the first-seen namespace per
+    dataset name. Malformed entries (non-dict event, non-list inputs/outputs)
+    are skipped defensively: a lineage artifact assembled from many emitters
+    routinely carries partial events, and one bad event should not abort the
+    walk.
+    """
+    upstream: dict[str, set[str]] = {}
+    downstream: dict[str, set[str]] = {}
+    namespaces: dict[str, str] = {}
+
+    def _register(dataset: Any) -> str | None:
+        if not isinstance(dataset, dict) or "name" not in dataset:
+            return None
+        name = str(dataset["name"])
+        if name not in namespaces:
+            namespaces[name] = str(dataset.get("namespace", ""))
+        return name
+
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        inputs = [n for n in (_register(d) for d in event.get("inputs", [])) if n is not None]
+        outputs = [n for n in (_register(d) for d in event.get("outputs", [])) if n is not None]
+        for out in outputs:
+            for inp in inputs:
+                upstream.setdefault(out, set()).add(inp)
+                downstream.setdefault(inp, set()).add(out)
+    return upstream, downstream, namespaces
+
+
+def _walk(
+    edge_map: dict[str, set[str]],
+    namespaces: dict[str, str],
+    start: str,
+    depth: int,
+    remaining: int,
+) -> list[dict[str, Any]]:
+    """BFS along ``edge_map`` from ``start`` up to ``depth`` hops; emit dataset rows.
+
+    Aborts once ``remaining`` rows have been emitted so ``result_limit`` bounds
+    the work walked, not just the output sliced (mirrors ``DbtManifestReader``).
+    """
+    if depth <= 0 or remaining <= 0:
+        return []
+    out: list[dict[str, Any]] = []
+    seen: set[str] = {start}
+    frontier: list[str] = [start]
+    for _ in range(depth):
+        next_frontier: list[str] = []
+        for node in frontier:
+            for neighbour in sorted(edge_map.get(node, set())):
+                if neighbour in seen:
+                    continue
+                seen.add(neighbour)
+                out.append({"name": neighbour, "namespace": namespaces.get(neighbour, "")})
+                if len(out) >= remaining:
+                    return out
+                next_frontier.append(neighbour)
+        if not next_frontier:
+            break
+        frontier = next_frontier
+    return out
+
+
+class OpenLineageReader(LineageReader):
+    CONNECTOR_ID: ClassVar[str] = "openlineage_events"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("locator",),)
+    # The TraversalMixin enum advertises Reactome-style ancestors / descendants
+    # for citation-shaped concretes; OpenLineage events describe a dataset
+    # input/output graph, so this walker dispatches on UPSTREAM / DOWNSTREAM /
+    # BOTH only (same disposition as DbtManifestReader).
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "lineage_direction": frozenset({"UPSTREAM", "DOWNSTREAM", "BOTH"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> dict[str, Any]:
+        """Return the parsed events document; mtime-cached so a 100-feature run pays one parse."""
+        return load_json_fixture(cls.CONNECTOR_ID, slot["locator"])
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        document = cls._connect_from_slot(ctx.slot)
+        params = cls.build_params(features, ctx.slot)
+
+        asset_urn = params.get("asset_urn")
+        if not asset_urn:
+            raise ValueError(f"{cls.CONNECTOR_ID}: 'asset_urn' is required.")
+        direction = params.get("lineage_direction", "BOTH")
+        upstream_depth = int(params.get("upstream_depth", 1))
+        downstream_depth = int(params.get("downstream_depth", 0))
+        result_limit = ctx.result_limit
+
+        events = document.get("events", [])
+        upstream_map, downstream_map, namespaces = _build_dataset_graph(events)
+
+        rows: list[dict[str, Any]] = []
+        if asset_urn in namespaces and result_limit > 0:
+            rows.append({"name": asset_urn, "namespace": namespaces[asset_urn]})
+
+        if direction in ("UPSTREAM", "BOTH") and len(rows) < result_limit:
+            rows.extend(_walk(upstream_map, namespaces, asset_urn, upstream_depth, result_limit - len(rows)))
+        if direction in ("DOWNSTREAM", "BOTH") and len(rows) < result_limit:
+            rows.extend(_walk(downstream_map, namespaces, asset_urn, downstream_depth, result_limit - len(rows)))
+
+        return rows
+
+
+class OpenLineageFeatureGroup(LineageFeatureGroup):
+    READER_CLASS: ClassVar[type[OpenLineageReader]] = OpenLineageReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/lineage/tests/fixtures/openlineage_events.json
+++ b/open_kgo/feature_groups/kg/lineage/tests/fixtures/openlineage_events.json
@@ -1,0 +1,23 @@
+{
+  "producer": "https://github.com/OpenLineage/OpenLineage/tree/1.0.0",
+  "events": [
+    {
+      "eventType": "COMPLETE",
+      "job": {"namespace": "food_delivery", "name": "ingest_orders"},
+      "inputs": [{"namespace": "food_delivery", "name": "raw.orders"}],
+      "outputs": [{"namespace": "food_delivery", "name": "stg_orders"}]
+    },
+    {
+      "eventType": "COMPLETE",
+      "job": {"namespace": "food_delivery", "name": "build_fct"},
+      "inputs": [{"namespace": "food_delivery", "name": "stg_orders"}],
+      "outputs": [{"namespace": "food_delivery", "name": "fct_orders"}]
+    },
+    {
+      "eventType": "COMPLETE",
+      "job": {"namespace": "food_delivery", "name": "build_report"},
+      "inputs": [{"namespace": "food_delivery", "name": "fct_orders"}],
+      "outputs": [{"namespace": "food_delivery", "name": "report_daily"}]
+    }
+  ]
+}

--- a/open_kgo/feature_groups/kg/lineage/tests/test_openlineage_events.py
+++ b/open_kgo/feature_groups/kg/lineage/tests/test_openlineage_events.py
@@ -32,7 +32,10 @@ class TestOpenLineageReader(LineageContractTestBase):
 
     @classmethod
     def invalid_credentials(cls) -> dict[str, Any]:
-        # Bad ``lineage_direction`` value triggers the SUPPORTED_VALUES narrowing.
+        # ``lineage_direction`` is a PARAMS key, so in the credential slot it is
+        # rejected by the closed-world unknown-credential-key check. (The
+        # strict-enum narrowing for it is exercised per-call by the inherited
+        # ``test_strict_validation_params_enums_rejected_per_key``.)
         return {"openlineage_events": {"locator": str(_FIXTURE), "lineage_direction": "SIDEWAYS"}}
 
     @classmethod

--- a/open_kgo/feature_groups/kg/lineage/tests/test_openlineage_events.py
+++ b/open_kgo/feature_groups/kg/lineage/tests/test_openlineage_events.py
@@ -1,0 +1,80 @@
+"""Concrete tests for OpenLineageReader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.lineage.openlineage_events import OpenLineageReader
+from open_kgo.feature_groups.kg.lineage.tests.kg_lineage_contract import (
+    LineageContractTestBase,
+)
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "openlineage_events.json"
+
+
+class TestOpenLineageReader(LineageContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[OpenLineageReader]:
+        return OpenLineageReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "openlineage_events": {
+                "locator": str(_FIXTURE),
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        # Bad ``lineage_direction`` value triggers the SUPPORTED_VALUES narrowing.
+        return {"openlineage_events": {"locator": str(_FIXTURE), "lineage_direction": "SIDEWAYS"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "openlineage_events__upstream",
+            options=Options(
+                context={
+                    "asset_urn": "fct_orders",
+                    "lineage_direction": "UPSTREAM",
+                    "upstream_depth": 2,
+                    "downstream_depth": 0,
+                }
+            ),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) >= 1 and "name" in result[0]
+
+    def test_upstream_walk_two_hops(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("openlineage_events", self.valid_credentials()["openlineage_events"], feat)
+        names = {r["name"] for r in rows}
+        assert names == {"fct_orders", "stg_orders", "raw.orders"}
+
+    def test_downstream_walk(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "openlineage_events__downstream",
+            options=Options(
+                context={
+                    "asset_urn": "fct_orders",
+                    "lineage_direction": "DOWNSTREAM",
+                    "upstream_depth": 0,
+                    "downstream_depth": 1,
+                }
+            ),
+        )
+        rows = run_query("openlineage_events", self.valid_credentials()["openlineage_events"], feat)
+        names = {r["name"] for r in rows}
+        assert names == {"fct_orders", "report_daily"}

--- a/open_kgo/feature_groups/kg/mixins.py
+++ b/open_kgo/feature_groups/kg/mixins.py
@@ -44,6 +44,31 @@ _CURSOR_FAMILY_STYLES: frozenset[str] = frozenset(
 )
 
 
+def parse_offset_cursor(connector_id: str, cursor_token: Any) -> int:
+    """Parse an opaque ``"offset:<N>"`` cursor token into a non-negative integer offset.
+
+    Shared by the cursor-paginating concretes (``PaginatedCitationReader``,
+    ``PaginatedTupleStoreReader``) so the opaque-token convention lives in one
+    place alongside ``PaginationMixin``. ``None`` (the first-page case) maps to
+    offset 0; a malformed token raises ``InvalidCredentialShape`` so a
+    hand-typed cursor surfaces a typed error rather than silently restarting
+    from the first page.
+    """
+    if cursor_token is None:
+        return 0
+    token = str(cursor_token)
+    if token.startswith("offset:"):
+        try:
+            offset = int(token.split(":", 1)[1])
+        except ValueError:
+            offset = -1
+        if offset >= 0:
+            return offset
+    raise InvalidCredentialShape(
+        f"{connector_id}: cursor_token {cursor_token!r} is malformed; expected 'offset:<N>' with N >= 0."
+    )
+
+
 _ENTITY_FILTER_KEYS: dict[str, Any] = {
     "entity_type": {
         "explanation": "Object type for the request (e.g. 'document', 'group').",

--- a/open_kgo/feature_groups/kg/network_pg/__init__.py
+++ b/open_kgo/feature_groups/kg/network_pg/__init__.py
@@ -4,8 +4,10 @@ Family base for graph DBs with property-graph data model and a vendor query
 language (Cypher / Gremlin / GSQL / nGQL / TypeQL). Adds ``dataset`` (database
 name), ``read_consistency``, ``transaction_mode``.
 
-PROTOTYPE NOTE: the only concrete plugin shipped here is KuzuDB embedded.
-Kuzu is property-graph + Cypher but has no network endpoint, so
-``read_consistency`` / ``transaction_mode`` are no-ops on it. The base
-validates property *shape* only.
+PROTOTYPE NOTE: both concretes are embedded. ``KuzuCypherReader`` runs Cypher
+against an embedded KuzuDB; ``GrandCypherReader`` runs openCypher against an
+in-memory NetworkX graph via ``grand-cypher``. Neither has a network endpoint,
+so ``read_consistency`` / ``transaction_mode`` are no-ops on both (waived for
+forward-compat). The base validates property *shape* only; a second Cypher
+engine on the same family base is backend variety, not new surface.
 """

--- a/open_kgo/feature_groups/kg/network_pg/grand_cypher.py
+++ b/open_kgo/feature_groups/kg/network_pg/grand_cypher.py
@@ -1,0 +1,99 @@
+"""GrandCypher-backed embedded Cypher reader.
+
+Second concrete in the ``network_pg`` family alongside ``KuzuCypherReader``:
+runs openCypher queries against an in-memory NetworkX graph via the pure-Python
+``grand-cypher`` library. Kuzu is an embedded C++ engine; GrandCypher is a
+Python Cypher interpreter over NetworkX, so the two share the family's
+Cypher-shaped contract on different substrates. Like Kuzu, this backend is
+single-process and embedded, so ``read_consistency`` / ``transaction_mode``
+are no-ops (waived, not narrowed: real network_pg backends will honor them).
+
+The graph is loaded from a GML / GraphML file at ``locator`` (NetworkX relabels
+GML nodes to their ``label``, keeping other attributes such as ``name``). The
+Cypher text comes from the Feature's options context under ``query_text``.
+GrandCypher returns a columnar ``{column: [values...]}`` dict, which we pivot
+into the family's row-oriented ``list[dict]`` shape, capped at ``result_limit``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+import networkx as nx
+from grandcypher import GrandCypher
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.fixtures import _rejected_scheme
+from open_kgo.feature_groups.kg.network_pg.base import (
+    NetworkPropertyGraphFeatureGroup,
+    NetworkPropertyGraphReader,
+)
+
+
+_LOADERS: dict[str, Any] = {
+    ".gml": nx.read_gml,
+    ".graphml": nx.read_graphml,
+}
+
+
+class GrandCypherReader(NetworkPropertyGraphReader):
+    CONNECTOR_ID: ClassVar[str] = "grand_cypher"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("locator",),)
+    # Waive read_consistency / transaction_mode: GrandCypher runs over an
+    # in-memory NetworkX graph (single process, no replicas / transactions), so
+    # both are no-ops here. Narrowing would lock the family contract to the
+    # embedded backends' single honored value and force future networked
+    # concretes (Neo4j, Memgraph) to widen — the same disposition as Kuzu.
+    _WAIVED_ENUM_KEYS: ClassVar[frozenset[str]] = frozenset({"read_consistency", "transaction_mode"})
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> nx.Graph:
+        """Load the NetworkX graph from ``slot['locator']`` (GML / GraphML).
+
+        Format is selected from the file extension. Remote locators are
+        rejected for parity with the other file-backed readers (NetworkX's
+        loaders only open local paths). A fresh graph is parsed per call,
+        matching ``NetworkxEmbeddedReader`` (NetworkX parsing of the small
+        fixtures is cheap; no shared cache is introduced for this family).
+        """
+        locator = slot.get("locator")
+        if not locator:
+            return nx.DiGraph()
+        bad = _rejected_scheme(locator)
+        if bad is not None:
+            raise ValueError(
+                f"{cls.CONNECTOR_ID}: locator scheme {bad!r} is not permitted; "
+                f"only local file paths or file:// URLs are allowed."
+            )
+        from pathlib import Path
+
+        loader = _LOADERS.get(Path(str(locator)).suffix.lower())
+        if loader is None:
+            raise ValueError(
+                f"{cls.CONNECTOR_ID}: unsupported graph file extension for locator {locator!r}; "
+                f"expected one of {sorted(_LOADERS)}."
+            )
+        return loader(str(locator))
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        graph = cls._connect_from_slot(ctx.slot)
+
+        query_text = cls.build_query(features)
+        # GrandCypher's ``limit`` bounds the number of matches it materialises,
+        # so the row cap is pushed into the engine rather than sliced after a
+        # full walk (short-circuit per the result_limit contract).
+        columns: dict[str, list[Any]] = GrandCypher(graph, limit=ctx.result_limit).run(query_text)
+
+        if not columns:
+            return []
+        # GrandCypher returns equal-length columns; pivot to row-oriented dicts.
+        row_count = min(len(values) for values in columns.values())
+        rows = [{column: values[i] for column, values in columns.items()} for i in range(row_count)]
+        return rows[: ctx.result_limit]
+
+
+class GrandCypherFeatureGroup(NetworkPropertyGraphFeatureGroup):
+    READER_CLASS: ClassVar[type[GrandCypherReader]] = GrandCypherReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/network_pg/tests/fixtures/org.gml
+++ b/open_kgo/feature_groups/kg/network_pg/tests/fixtures/org.gml
@@ -1,0 +1,8 @@
+graph [
+  directed 1
+  node [ id 0 label "alice" name "Alice" team "platform" ]
+  node [ id 1 label "bob" name "Bob" team "platform" ]
+  node [ id 2 label "carol" name "Carol" team "data" ]
+  edge [ source 0 target 1 label "MANAGES" ]
+  edge [ source 1 target 2 label "MANAGES" ]
+]

--- a/open_kgo/feature_groups/kg/network_pg/tests/test_grand_cypher.py
+++ b/open_kgo/feature_groups/kg/network_pg/tests/test_grand_cypher.py
@@ -1,0 +1,93 @@
+"""Concrete tests for GrandCypherReader.
+
+Runs openCypher against an in-memory NetworkX graph loaded from a committed
+GML fixture. Exercises the network_pg property layout against a second Cypher
+engine; like Kuzu it does NOT exercise read_consistency / transaction_mode
+semantics (both no-op on an embedded backend).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.network_pg.grand_cypher import GrandCypherReader
+from open_kgo.feature_groups.kg.network_pg.tests.kg_network_pg_contract import (
+    NetworkPropertyGraphContractTestBase,
+)
+
+
+_FIXTURE_GML = Path(__file__).parent / "fixtures" / "org.gml"
+
+
+class TestGrandCypherReader(NetworkPropertyGraphContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[GrandCypherReader]:
+        return GrandCypherReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "grand_cypher": {
+                "locator": str(_FIXTURE_GML),
+                "dataset": "default",
+                "read_consistency": "read",
+                "transaction_mode": "auto",
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        # read_consistency is waived (accepted at the family-allowed set) but a
+        # value OUTSIDE that set still rejects via the family enum check.
+        return {"grand_cypher": {"locator": str(_FIXTURE_GML), "read_consistency": "evil"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "grand_cypher__list_names",
+            options=Options(context={"query_text": "MATCH (n) RETURN n.name"}),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) == 3
+
+    def test_cypher_returns_three_names(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("grand_cypher", self.valid_credentials()["grand_cypher"], feat)
+        names = sorted(r["n.name"] for r in rows)
+        assert names == ["Alice", "Bob", "Carol"]
+
+    def test_directed_edge_query(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "grand_cypher__manages",
+            options=Options(context={"query_text": "MATCH (a)-[]->(b) RETURN a.name, b.name"}),
+        )
+        rows = run_query("grand_cypher", self.valid_credentials()["grand_cypher"], feat)
+        pairs = sorted((r["a.name"], r["b.name"]) for r in rows)
+        assert pairs == [("Alice", "Bob"), ("Bob", "Carol")]
+
+    def test_result_limit_truncates_rows(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = dict(self.valid_credentials()["grand_cypher"])
+        slot["result_limit"] = 2
+        feat = self.feature_under_test()
+        rows = run_query("grand_cypher", slot, feat)
+        assert len(rows) == 2
+
+    def test_http_locator_rejected(self) -> None:
+        cls = self.connector_reader_class()
+        creds = {cls.CONNECTOR_ID: {"locator": "http://example.com/evil.gml"}}
+        with pytest.raises(ValueError, match="scheme"):
+            cls.connect(creds)

--- a/open_kgo/feature_groups/kg/rdf/__init__.py
+++ b/open_kgo/feature_groups/kg/rdf/__init__.py
@@ -5,14 +5,13 @@ Family-base properties (beyond the universal layer) follow Version B of
 ``named_graph_uris``, ``update_endpoint``, ``result_format``, plus
 ``reasoning_profile`` from ``InferenceMixin``.
 
-PROTOTYPE NOTE: ``RdfLibSparqlReader`` validates property *shape* only for
-several keys. ``result_format`` is strict-validated against the SPARQL
-results-media-type enum but the reader always returns Python dicts
-regardless of the value. ``default_graph_uris``, ``named_graph_uris``, and
-``update_endpoint`` are accepted but never read at runtime (rdflib's
-in-memory graph has no notion of named graphs in this prototype).
-``reasoning_profile`` is strict-validated against
-``{none, rdfs, owl-rl, owl-dl, custom}`` but only ``"none"`` works; any
-other value would raise ``NotImplementedError`` if the inference path were
-wired in (it isn't — see ``mixins.py``).
+PROTOTYPE NOTE: two SPARQL engines back this family — ``RdfLibSparqlReader``
+(``rdflib``) and ``OxigraphSparqlReader`` (``pyoxigraph``, a Rust-backed
+embedded store). Both validate property *shape* only for several keys and
+return Python dicts, so ``result_format`` stays narrowed to JSON on both.
+``default_graph_uris``, ``named_graph_uris``, and ``update_endpoint`` are
+accepted but never read at runtime. ``reasoning_profile`` is strict-validated
+against ``{none, rdfs, owl-rl, owl-dl, custom}`` but neither engine has an
+inference path wired in, so both narrow it to ``"none"``. A second SPARQL
+engine on the same family base is backend variety, not new surface.
 """

--- a/open_kgo/feature_groups/kg/rdf/oxigraph_sparql.py
+++ b/open_kgo/feature_groups/kg/rdf/oxigraph_sparql.py
@@ -1,0 +1,103 @@
+"""Concrete RDF/SPARQL connector backed by an in-memory ``pyoxigraph.Store``.
+
+Second concrete in the ``rdf`` family alongside ``RdfLibSparqlReader``: parses
+a Turtle/N-Triples/RDF-XML file at ``locator`` into an embedded oxigraph store
+and runs SPARQL 1.1 queries against it. oxigraph is a different SPARQL engine
+(Rust-backed) than rdflib, so this proves the family base generalises across
+implementations; it does not unlock new family surface (oxigraph has no RDFS
+inference and we return JSON-binding-shaped rows, so ``reasoning_profile`` and
+``result_format`` stay narrowed exactly as on ``RdfLibSparqlReader``).
+
+The query text comes from the Feature's options context under ``query_text``.
+``result_limit`` is enforced by breaking out of solution iteration once the cap
+is reached (short-circuit, not slice-at-end). SELECT results map to
+JSON-binding-shaped dicts; CONSTRUCT/DESCRIBE map to ``s``/``p``/``o`` triple
+rows; ASK maps to a single ``{"boolean": ...}`` row.
+"""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar, Mapping
+
+import pyoxigraph
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.fixtures import _rejected_scheme, load_oxigraph_store
+from open_kgo.feature_groups.kg.rdf.base import RdfSparqlFeatureGroup, RdfSparqlReader
+
+
+class OxigraphSparqlReader(RdfSparqlReader):
+    """pyoxigraph in-memory SPARQL reader.
+
+    Accepts an optional ``locator`` (path to a turtle/n-triples/rdf-xml file).
+    With ``locator=None`` the reader runs against an empty store, which is only
+    useful for shape tests.
+    """
+
+    CONNECTOR_ID: ClassVar[str] = "oxigraph_sparql"
+    # Strict-enum narrowings (identical disposition to RdfLibSparqlReader):
+    #   - result_format: SELECT solutions are converted to JSON-binding-shaped
+    #     dicts; XML / Turtle / N-Triples serialisations are not honored.
+    #   - reasoning_profile: oxigraph has no inference engine, so only "none".
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "result_format": frozenset({"application/sparql-results+json"}),
+        "reasoning_profile": frozenset({"none"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> Any:
+        """Return a shared, path-cached ``pyoxigraph.Store`` populated from ``slot['locator']``.
+
+        Routes through the shared ``load_oxigraph_store`` cache (mtime-keyed)
+        so a 100-feature ``mloda.run_all`` pays one parse instead of one
+        hundred. The returned store is shared across calls and MUST be treated
+        as read-only. ``locator=None``/falsy stays out of the cache: a fresh
+        empty store is built per call, which is what the empty-store shape
+        tests document. The scheme guard keeps the file-only contract (and its
+        ``ValueError`` flavour) uniform with ``RdfLibSparqlReader``.
+        """
+        locator = slot.get("locator")
+        if not locator:
+            return pyoxigraph.Store()
+        bad = _rejected_scheme(locator)
+        if bad is not None:
+            raise ValueError(
+                f"{cls.CONNECTOR_ID}: locator scheme {bad!r} is not permitted; "
+                f"only local file paths or file:// URLs are allowed."
+            )
+        return load_oxigraph_store(cls.CONNECTOR_ID, locator)
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        """Run the SPARQL query and return up to result_limit rows as list-of-dicts."""
+        ctx = cls._prepare_load(data_access)
+        store = cls._connect_from_slot(ctx.slot)
+
+        query_text = cls.build_query(features)
+        result = store.query(query_text)
+        rows: list[dict[str, Any]] = []
+
+        if isinstance(result, pyoxigraph.QuerySolutions):
+            variables = result.variables
+            for solution in result:
+                rows.append(
+                    {var.value: (solution[var].value if solution[var] is not None else None) for var in variables}
+                )
+                if len(rows) >= ctx.result_limit:
+                    break
+            return rows
+
+        if isinstance(result, pyoxigraph.QueryBoolean):
+            return [{"boolean": bool(result)}]
+
+        # CONSTRUCT / DESCRIBE -> iterator of pyoxigraph.Triple.
+        for triple in result:
+            rows.append({"s": triple.subject.value, "p": triple.predicate.value, "o": triple.object.value})
+            if len(rows) >= ctx.result_limit:
+                break
+        return rows
+
+
+class OxigraphSparqlFeatureGroup(RdfSparqlFeatureGroup):
+    READER_CLASS: ClassVar[type[OxigraphSparqlReader]] = OxigraphSparqlReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/rdf/tests/test_oxigraph_sparql.py
+++ b/open_kgo/feature_groups/kg/rdf/tests/test_oxigraph_sparql.py
@@ -1,0 +1,112 @@
+"""Concrete tests for OxigraphSparqlReader.
+
+Reuses the committed ``sample.ttl`` fixture (shared with the rdflib reader) so
+both SPARQL engines are asserted against the same triples, demonstrating the
+RDF family base generalises across implementations.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.errors import FixtureLoadError
+from open_kgo.feature_groups.kg.rdf.oxigraph_sparql import OxigraphSparqlReader
+from open_kgo.feature_groups.kg.rdf.tests.kg_rdf_contract import RdfContractTestBase
+
+
+_FIXTURE_TTL = Path(__file__).parent / "fixtures" / "sample.ttl"
+
+
+class TestOxigraphSparqlReader(RdfContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[OxigraphSparqlReader]:
+        return OxigraphSparqlReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "oxigraph_sparql": {
+                "locator": str(_FIXTURE_TTL),
+                "result_format": "application/sparql-results+json",
+                "reasoning_profile": "none",
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        # ``reasoning_profile`` is narrowed to ``{"none"}``; any other
+        # family-allowed value (e.g. ``"rdfs"``) is outside the narrowed set.
+        return {"oxigraph_sparql": {"locator": str(_FIXTURE_TTL), "reasoning_profile": "rdfs"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature(
+            "oxigraph_sparql__select_knows",
+            options=Options(
+                context={
+                    "query_text": (
+                        "PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT ?s ?o WHERE { ?s foaf:knows ?o } LIMIT 10"
+                    ),
+                }
+            ),
+        )
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        def _check(result: Any) -> bool:
+            if not isinstance(result, list) or len(result) == 0:
+                return False
+            return all(isinstance(row, dict) and "s" in row and "o" in row for row in result)
+
+        return _check
+
+    def test_query_returns_three_knows_triples(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("oxigraph_sparql", self.valid_credentials()["oxigraph_sparql"], feat)
+        assert len(rows) == 3
+
+    def test_result_limit_truncates_emitted_rows(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = dict(self.valid_credentials()["oxigraph_sparql"])
+        slot["result_limit"] = 2
+        feat = self.feature_under_test()
+        rows = run_query("oxigraph_sparql", slot, feat)
+        assert len(rows) == 2
+
+    def test_ask_query_returns_boolean_row(self) -> None:
+        """An ASK query maps to a single ``{"boolean": ...}`` row."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature(
+            "oxigraph_sparql__ask_knows",
+            options=Options(
+                context={
+                    "query_text": "PREFIX foaf: <http://xmlns.com/foaf/0.1/> ASK { ?s foaf:knows ?o }",
+                }
+            ),
+        )
+        rows = run_query("oxigraph_sparql", self.valid_credentials()["oxigraph_sparql"], feat)
+        assert rows == [{"boolean": True}]
+
+    def test_http_locator_rejected(self) -> None:
+        """connect() must refuse remote schemes (no network IO at fetch time)."""
+        cls = self.connector_reader_class()
+        creds = {cls.CONNECTOR_ID: {"locator": "http://example.com/evil.ttl"}}
+        with pytest.raises(ValueError, match="scheme"):
+            cls.connect(creds)
+
+    def test_missing_locator_file_is_typed(self) -> None:
+        """A ``locator`` pointing at a non-existent file raises ``FixtureLoadError``."""
+        cls = self.connector_reader_class()
+        creds = {cls.CONNECTOR_ID: {"locator": "/nonexistent/path/to/graph.ttl"}}
+        with pytest.raises(FixtureLoadError):
+            cls.connect(creds)

--- a/open_kgo/feature_groups/kg/rdf/tests/test_oxigraph_sparql.py
+++ b/open_kgo/feature_groups/kg/rdf/tests/test_oxigraph_sparql.py
@@ -110,3 +110,18 @@ class TestOxigraphSparqlReader(RdfContractTestBase):
         creds = {cls.CONNECTOR_ID: {"locator": "/nonexistent/path/to/graph.ttl"}}
         with pytest.raises(FixtureLoadError):
             cls.connect(creds)
+
+    def test_malformed_rdf_locator_is_typed(self, tmp_path: Path) -> None:
+        """A present-but-unparseable Turtle file raises ``FixtureLoadError``.
+
+        Exercises the parse-failure branch in ``load_oxigraph_store`` (pyoxigraph
+        raises the builtin ``SyntaxError``, wrapped as ``FixtureLoadError``), so a
+        future pyoxigraph exception-type change surfaces as a test failure rather
+        than a leaked untyped error.
+        """
+        cls = self.connector_reader_class()
+        bad = tmp_path / "bad.ttl"
+        bad.write_text("@prefix ex: <http://example.org/> .\nex:s ex:p <<< not turtle", encoding="utf-8")
+        creds = {cls.CONNECTOR_ID: {"locator": str(bad)}}
+        with pytest.raises(FixtureLoadError):
+            cls.connect(creds)

--- a/open_kgo/feature_groups/kg/rest_public/__init__.py
+++ b/open_kgo/feature_groups/kg/rest_public/__init__.py
@@ -4,11 +4,12 @@ The locator is a base URL, ``dataset`` is null (one URL is the corpus). Family
 adds: ``entity_type``, ``dataset_version``, ``user_agent``, ``rate_limit_pace``.
 Inherits ``PaginationMixin`` (cursor / page / cursorMark / etc.).
 
-PROTOTYPE NOTE: the only concrete plugin is ``FileFixtureRestReader``, which
-walks ``page_*.json`` files on disk. ``pagination_style`` is strict-validated
-against the 7-value enum but the page walker hardcodes cursor-style
-termination on ``meta.next_cursor`` and does not switch on the enum value.
-``rate_limit_pace``, ``user_agent``, ``entity_type``, and ``dataset_version``
-are accepted at the property layer and never read at runtime — there is no
-real HTTP client to apply them to.
+PROTOTYPE NOTE: both concretes walk ``page_*.json`` files on disk.
+``FileFixtureRestReader`` narrows ``pagination_style`` to ``cursor`` and
+terminates on ``meta.next_cursor`` (dropping ``page_size``).
+``FileFixturePagedRestReader`` narrows it to ``page`` and *honors*
+``page_size``, terminating when a page returns fewer than ``page_size`` rows —
+so the family's counter-pagination branch is now exercised. ``rate_limit_pace``,
+``user_agent``, ``entity_type``, and ``dataset_version`` remain accepted at the
+property layer and never read (there is no real HTTP client to apply them to).
 """

--- a/open_kgo/feature_groups/kg/rest_public/file_fixture_paged_rest.py
+++ b/open_kgo/feature_groups/kg/rest_public/file_fixture_paged_rest.py
@@ -1,0 +1,85 @@
+"""File-fixture REST connector using page-number pagination.
+
+Second concrete in the ``rest_public`` family alongside ``FileFixtureRestReader``
+(which uses opaque-cursor pagination). This reader exercises the family's
+*counter* pagination branch: ``pagination_style=page`` plus ``page_size`` — the
+two surfaces the cursor concrete narrows away (it pins ``pagination_style`` to
+``cursor`` and drops ``page_size``). It therefore proves the PaginationMixin's
+page/page_size contract is real, modelling page-number APIs such as GBIF or the
+GitHub REST API rather than OpenAlex cursors.
+
+The ``locator`` points to a directory of ``page_<N>.json`` files, each shaped
+like ``{"results": [...rows...]}``. The reader walks pages in numeric order and
+stops at the first page returning fewer than ``page_size`` rows (the standard
+page-number end-of-collection signal), or when ``result_limit`` is reached.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any, ClassVar, Mapping
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.fixtures import copy_cached_row, load_json_fixture
+from open_kgo.feature_groups.kg.rest_public.base import (
+    RestPublicFeatureGroup,
+    RestPublicReader,
+)
+
+
+def _page_index(page_file: Path) -> int:
+    """Return the integer ``<N>`` from a ``page_<N>.json`` filename for numeric sort."""
+    match = re.search(r"\d+", page_file.stem)
+    return int(match.group()) if match else 0
+
+
+class FileFixturePagedRestReader(RestPublicReader):
+    CONNECTOR_ID: ClassVar[str] = "file_fixture_paged_rest"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("locator",),)
+
+    # ``page_size`` is RETAINED (the new surface this concrete honors, vs. the
+    # cursor concrete which drops it). ``cursor_token`` and ``entity_type`` are
+    # dropped from PARAMS_MAPPING and rejected per-call via ``_STRIPPED_PARAMS``.
+    PARAMS_MAPPING: ClassVar[dict[str, Any]] = {}
+
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "pagination_style": frozenset({"page"}),
+    }
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> Path:
+        """Return the locator directory; pages are read lazily in load_data."""
+        path = Path(str(slot["locator"]))
+        if not path.exists():
+            raise FileNotFoundError(f"{cls.CONNECTOR_ID}: locator path {path} does not exist.")
+        return path
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        path = cls._connect_from_slot(ctx.slot)
+
+        page_size = int(ctx.slot.get("page_size", 100))
+        pages_dir = path if path.is_dir() else path.parent
+        page_files = sorted(pages_dir.glob("page_*.json"), key=_page_index)
+
+        rows: list[dict[str, Any]] = []
+        for page_file in page_files:
+            body = load_json_fixture(cls.CONNECTOR_ID, page_file)
+            results = body.get("results", [])
+            for row in results:
+                rows.append(copy_cached_row(row))
+                if len(rows) >= ctx.result_limit:
+                    return rows
+            # Page-number termination: a page shorter than ``page_size`` is the
+            # last page of the collection, so stop rather than reading further
+            # files (mirrors how a real page-number API signals exhaustion).
+            if len(results) < page_size:
+                break
+        return rows
+
+
+class FileFixturePagedRestFeatureGroup(RestPublicFeatureGroup):
+    READER_CLASS: ClassVar[type[FileFixturePagedRestReader]] = FileFixturePagedRestReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/rest_public/tests/fixtures/paged/page_1.json
+++ b/open_kgo/feature_groups/kg/rest_public/tests/fixtures/paged/page_1.json
@@ -1,0 +1,6 @@
+{
+  "results": [
+    {"id": "P001", "title": "Paged One"},
+    {"id": "P002", "title": "Paged Two"}
+  ]
+}

--- a/open_kgo/feature_groups/kg/rest_public/tests/fixtures/paged/page_2.json
+++ b/open_kgo/feature_groups/kg/rest_public/tests/fixtures/paged/page_2.json
@@ -1,0 +1,5 @@
+{
+  "results": [
+    {"id": "P003", "title": "Paged Three"}
+  ]
+}

--- a/open_kgo/feature_groups/kg/rest_public/tests/test_file_fixture_paged_rest.py
+++ b/open_kgo/feature_groups/kg/rest_public/tests/test_file_fixture_paged_rest.py
@@ -1,0 +1,93 @@
+"""Concrete tests for FileFixturePagedRestReader."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.provider import HashableDict
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.errors import InvalidCredentialShape
+from open_kgo.feature_groups.kg.rest_public.file_fixture_paged_rest import (
+    FileFixturePagedRestReader,
+)
+from open_kgo.feature_groups.kg.rest_public.tests.kg_rest_public_contract import (
+    RestPublicContractTestBase,
+)
+
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "paged"
+
+
+class TestFileFixturePagedRestReader(RestPublicContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[FileFixturePagedRestReader]:
+        return FileFixturePagedRestReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "file_fixture_paged_rest": {
+                "locator": str(_FIXTURE_DIR),
+                "pagination_style": "page",
+                "page_size": 2,
+                "rate_limit_pace": 100,
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        return {"file_fixture_paged_rest": {"locator": str(_FIXTURE_DIR), "pagination_style": "evil"}}
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature("file_fixture_paged_rest__list", options=Options(context={}))
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: isinstance(result, list) and len(result) >= 1 and "id" in result[0]
+
+    def test_page_pagination_yields_three_total_rows(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("file_fixture_paged_rest", self.valid_credentials()["file_fixture_paged_rest"], feat)
+        assert {r["id"] for r in rows} == {"P001", "P002", "P003"}
+
+    def test_page_size_terminates_walk(self, tmp_path: Path) -> None:
+        """A page shorter than ``page_size`` ends the walk; later pages are not read.
+
+        page_1 has page_size rows (full) and page_2 has fewer (partial → last),
+        so page_3 must never be reached even though the file exists.
+        """
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        (tmp_path / "page_1.json").write_text(json.dumps({"results": [{"id": "A1"}, {"id": "A2"}]}), encoding="utf-8")
+        (tmp_path / "page_2.json").write_text(json.dumps({"results": [{"id": "B1"}]}), encoding="utf-8")
+        (tmp_path / "page_3.json").write_text(json.dumps({"results": [{"id": "C1"}]}), encoding="utf-8")
+
+        slot = dict(self.valid_credentials()["file_fixture_paged_rest"])
+        slot["locator"] = str(tmp_path)
+        rows = run_query("file_fixture_paged_rest", slot, self.feature_under_test())
+        assert [r["id"] for r in rows] == ["A1", "A2", "B1"]
+
+    @pytest.mark.parametrize("style", ["cursor", "offset", "odata-nextLink", "cursorMark", "start_rows", "none"])
+    def test_unsupported_pagination_styles_rejected_at_validate_time(self, style: str) -> None:
+        slot = dict(self.valid_credentials()["file_fixture_paged_rest"])
+        slot["pagination_style"] = style
+        creds = HashableDict({"file_fixture_paged_rest": slot})
+        assert FileFixturePagedRestReader.is_valid_credentials(creds) is False
+        with pytest.raises(InvalidCredentialShape):
+            FileFixturePagedRestReader._validate_shape(slot)
+
+    def test_page_size_is_honored_in_property_mapping(self) -> None:
+        """Unlike the cursor concrete, ``page_size`` is a valid credential key here."""
+        slot = dict(self.valid_credentials()["file_fixture_paged_rest"])
+        slot["page_size"] = 5
+        creds = HashableDict({"file_fixture_paged_rest": slot})
+        assert FileFixturePagedRestReader.is_valid_credentials(creds) is True

--- a/open_kgo/feature_groups/kg/saas_authz/__init__.py
+++ b/open_kgo/feature_groups/kg/saas_authz/__init__.py
@@ -6,10 +6,15 @@ subdomain, instance_url, store_id, token-implicit, wiki_url, vault_path).
 ``expand_paths`` for OData / permission-tree expansion.
 
 PROTOTYPE NOTE: ``InProcessTupleStoreReader`` is pinned to a canonical
-``fixtures/tuples.json`` (ships ``tenant_a``); the ``locator`` credential
-slot is dropped on this concrete because the fixture is baked into the
-class. A ``tenant`` outside the closed ``allowed_values`` enum is rejected
-at ``is_valid_credentials`` time (matcher-safe); direct callers that bypass
-validation hit ``UnknownTenantError`` at ``connect()``. An unreadable /
-malformed fixture raises ``FixtureLoadError``.
+``fixtures/tuples.json`` (ships ``tenant_a``); the ``locator`` slot is
+dropped and ``tenant`` is a closed enum. It pins ``pagination_style=none``
+and does no group expansion.
+
+SECOND CONCRETE: ``PaginatedTupleStoreReader`` takes a configurable
+``locator`` (open ``tenant``, ``UnknownTenantError`` at connect like
+agent_memory) and *honors* the dropped surface: cursor pagination
+(``pagination_style=cursor`` + ``page_size`` + ``cursor_token``) and
+``expand_paths`` (structural ``group:<id>#<rel>`` userset expansion). Neither
+concrete implements real Zanzibar consistency-token semantics;
+``consistency_mode`` is waived on both.
 """

--- a/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
@@ -1,0 +1,140 @@
+"""In-process tuple store that paginates results and expands group usersets.
+
+Second concrete in the ``saas_authz`` family alongside
+``InProcessTupleStoreReader`` (single-page, no expansion). This reader *honors*
+the family surface the first concrete pins off: cursor pagination
+(``pagination_style=cursor`` + ``page_size`` + per-call ``cursor_token``) and
+``expand_paths`` (structural transitive group expansion). It is the family's
+proof that the pagination + expand contract is real.
+
+HONESTY NOTE: like the first concrete, this is a shape-only fake. It does NOT
+implement real Zanzibar consistency tokens, model-id versioning, or namespaced
+check evaluation; ``consistency_mode`` is accepted but not honored (waived). The
+expansion is a single structural pass: a tuple whose user is a userset
+reference (``group:<id>#<rel>``) is replaced by the members of that group when
+``<rel>`` is listed in ``expand_paths``.
+
+The tuples are loaded from a JSON fixture at ``locator`` (shape:
+``{tenant: [[object_type, object_id, relation, user], ...]}``). An unknown
+tenant raises ``UnknownTenantError`` at connect time (the agent_memory
+``UnknownMemoryScopeError`` precedent), so ``tenant`` stays open (non-strict)
+rather than pinned to a closed enum.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import Any, ClassVar, Mapping
+
+from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+from open_kgo.feature_groups.kg.errors import FixtureLoadError, UnknownTenantError
+from open_kgo.feature_groups.kg.fixtures import load_json_fixture
+from open_kgo.feature_groups.kg.mixins import parse_offset_cursor
+from open_kgo.feature_groups.kg.saas_authz.base import (
+    SaasAuthzFeatureGroup,
+    SaasAuthzReader,
+)
+
+_Tuple = tuple[str, str, str, str]
+
+
+def _validate_tuples(connector_id: str, locator: str, tenant: str, raw: Any) -> list[_Tuple]:
+    """Raise ``FixtureLoadError`` unless ``raw`` is a list of 4-string tuples; return as ``list[tuple]``."""
+    if not isinstance(raw, list):
+        raise FixtureLoadError(
+            connector_id, locator, f"tenant {tenant!r} entry must be a list, got {type(raw).__name__}."
+        )
+    out: list[_Tuple] = []
+    for index, item in enumerate(raw):
+        if not isinstance(item, list) or len(item) != 4 or not all(isinstance(s, str) for s in item):
+            raise FixtureLoadError(
+                connector_id,
+                locator,
+                f"tenant {tenant!r} index {index}: each tuple must be a list of 4 strings, got {item!r}.",
+            )
+        out.append((item[0], item[1], item[2], item[3]))
+    return out
+
+
+def _expand_usersets(rows: list[_Tuple], all_tuples: list[_Tuple], expand_paths: tuple[str, ...]) -> list[_Tuple]:
+    """Replace ``group:<id>#<rel>`` users in ``rows`` with that group's members.
+
+    The membership index is built from ``all_tuples`` (not the filtered
+    ``rows``) so group-membership tuples removed by an ``entity_type`` /
+    ``relationship_type`` filter are still available to resolve a userset.
+    Only usersets whose ``<rel>`` is listed in ``expand_paths`` are expanded;
+    everything else passes through unchanged.
+    """
+    if not expand_paths:
+        return rows
+    members: dict[tuple[str, str], list[str]] = defaultdict(list)
+    for object_type, object_id, relation, user in all_tuples:
+        if object_type == "group":
+            members[(object_id, relation)].append(user)
+
+    expanded: list[_Tuple] = []
+    for object_type, object_id, relation, user in rows:
+        if user.startswith("group:") and "#" in user:
+            group_ref = user[len("group:") :]
+            group_id, _, group_rel = group_ref.partition("#")
+            if group_rel in expand_paths:
+                for member_user in members.get((group_id, group_rel), []):
+                    expanded.append((object_type, object_id, relation, member_user))
+                continue
+        expanded.append((object_type, object_id, relation, user))
+    return expanded
+
+
+class PaginatedTupleStoreReader(SaasAuthzReader):
+    CONNECTOR_ID: ClassVar[str] = "paginated_tuple_store"
+    REQUIRED_KEYS: ClassVar[tuple[tuple[str, ...], ...]] = (("locator",), ("tenant",))
+
+    # pagination_style is narrowed to the cursor style this reader implements;
+    # page_size, cursor_token, and expand_paths are RETAINED (the new surface).
+    SUPPORTED_VALUES: ClassVar[Mapping[str, frozenset[Any]]] = {
+        "pagination_style": frozenset({"cursor"}),
+    }
+    # Waive consistency_mode: accepted for forward-compat but this fake
+    # implements no consistency semantics (same disposition as the first
+    # concrete; real SpiceDB / OpenFGA backends will dispatch on it).
+    _WAIVED_ENUM_KEYS: ClassVar[frozenset[str]] = frozenset({"consistency_mode"})
+
+    @classmethod
+    def _connect_from_slot(cls, slot: Mapping[str, Any]) -> list[_Tuple]:
+        locator = str(slot["locator"])
+        stores = load_json_fixture(cls.CONNECTOR_ID, locator)
+        tenant = str(slot["tenant"])
+        if tenant not in stores:
+            raise UnknownTenantError(cls.CONNECTOR_ID, tenant)
+        return _validate_tuples(cls.CONNECTOR_ID, locator, tenant, stores[tenant])
+
+    @classmethod
+    def load_data(cls, data_access: Any, features: FeatureSet) -> list[dict[str, Any]]:
+        ctx = cls._prepare_load(data_access)
+        all_tuples = cls._connect_from_slot(ctx.slot)
+        # Engages PaginationMixin._validate_cross_layer (cursor_token requires a
+        # cursor-family pagination_style, which this concrete pins).
+        params = cls.build_params(features, ctx.slot)
+
+        # entity_type / relationship_type are connector defaults (slot-level).
+        entity_type = ctx.slot.get("entity_type")
+        relationship_type = ctx.slot.get("relationship_type")
+        expand_paths = tuple(ctx.slot.get("expand_paths") or ())
+        offset = parse_offset_cursor(cls.CONNECTOR_ID, params.get("cursor_token"))
+        page_size = int(ctx.slot.get("page_size", 100))
+
+        filtered = [
+            t
+            for t in all_tuples
+            if (entity_type is None or t[0] == entity_type) and (relationship_type is None or t[2] == relationship_type)
+        ]
+        expanded = _expand_usersets(filtered, all_tuples, expand_paths)
+        expanded.sort()
+
+        page = expanded[offset : offset + page_size][: ctx.result_limit]
+        return [{"object_type": ot, "object_id": oid, "relation": rel, "user": user} for ot, oid, rel, user in page]
+
+
+class PaginatedTupleStoreFeatureGroup(SaasAuthzFeatureGroup):
+    READER_CLASS: ClassVar[type[PaginatedTupleStoreReader]] = PaginatedTupleStoreReader  # type: ignore[assignment]

--- a/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
@@ -65,6 +65,12 @@ def _expand_usersets(rows: list[_Tuple], all_tuples: list[_Tuple], expand_paths:
     ``relationship_type`` filter are still available to resolve a userset.
     Only usersets whose ``<rel>`` is listed in ``expand_paths`` are expanded;
     everything else passes through unchanged.
+
+    Structural-expansion semantics: an expanded userset that resolves to no
+    members (an empty or absent group) yields **zero** grants — the original
+    ``group:<id>#<rel>`` row is replaced by its (empty) membership, so it drops
+    out of the result. A userset whose ``<rel>`` is NOT in ``expand_paths`` is
+    left untouched and passes through as-is.
     """
     if not expand_paths:
         return rows

--- a/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/paginated_tuple_store.py
@@ -79,7 +79,10 @@ def _expand_usersets(rows: list[_Tuple], all_tuples: list[_Tuple], expand_paths:
             group_ref = user[len("group:") :]
             group_id, _, group_rel = group_ref.partition("#")
             if group_rel in expand_paths:
-                for member_user in members.get((group_id, group_rel), []):
+                # dict.fromkeys dedupes members defined by repeated membership
+                # tuples while preserving order, so the expansion can't emit the
+                # same (object, user) grant twice.
+                for member_user in dict.fromkeys(members.get((group_id, group_rel), [])):
                     expanded.append((object_type, object_id, relation, member_user))
                 continue
         expanded.append((object_type, object_id, relation, user))

--- a/open_kgo/feature_groups/kg/saas_authz/tests/fixtures/tuples_b.json
+++ b/open_kgo/feature_groups/kg/saas_authz/tests/fixtures/tuples_b.json
@@ -1,0 +1,11 @@
+{
+  "tenant_b": [
+    ["document", "doc1", "viewer", "user:alice"],
+    ["document", "doc1", "viewer", "user:bob"],
+    ["document", "doc2", "viewer", "user:carol"],
+    ["document", "doc3", "viewer", "user:dave"],
+    ["document", "doc4", "viewer", "group:eng#member"],
+    ["group", "eng", "member", "user:erin"],
+    ["group", "eng", "member", "user:frank"]
+  ]
+}

--- a/open_kgo/feature_groups/kg/saas_authz/tests/test_paginated_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/tests/test_paginated_tuple_store.py
@@ -1,0 +1,138 @@
+"""Concrete tests for PaginatedTupleStoreReader."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+import pytest
+
+from mloda.user import Feature, Options
+
+from open_kgo.feature_groups.kg.errors import InvalidCredentialShape, UnknownTenantError
+from open_kgo.feature_groups.kg.saas_authz.paginated_tuple_store import (
+    PaginatedTupleStoreReader,
+)
+from open_kgo.feature_groups.kg.saas_authz.tests.kg_saas_authz_contract import (
+    SaasAuthzContractTestBase,
+)
+
+
+_FIXTURE = Path(__file__).parent / "fixtures" / "tuples_b.json"
+
+
+class TestPaginatedTupleStoreReader(SaasAuthzContractTestBase):
+    @classmethod
+    def connector_reader_class(cls) -> type[PaginatedTupleStoreReader]:
+        return PaginatedTupleStoreReader
+
+    @classmethod
+    def valid_credentials(cls) -> dict[str, Any]:
+        return {
+            "paginated_tuple_store": {
+                "locator": str(_FIXTURE),
+                "tenant": "tenant_b",
+                "api_version": "v1.0",
+                "relationship_type": "viewer",
+                "consistency_mode": "minimize_latency",
+                "pagination_style": "cursor",
+                "page_size": 2,
+                "result_limit": 100,
+            }
+        }
+
+    @classmethod
+    def invalid_credentials(cls) -> dict[str, Any]:
+        return {
+            "paginated_tuple_store": {
+                "locator": str(_FIXTURE),
+                "tenant": "tenant_b",
+                "consistency_mode": "evil",
+            }
+        }
+
+    @classmethod
+    def feature_under_test(cls) -> Feature:
+        return Feature("paginated_tuple_store__viewers", options=Options(context={}))
+
+    @classmethod
+    def expected_row_shape(cls) -> Callable[[Any], bool]:
+        return lambda result: (
+            isinstance(result, list) and len(result) >= 1 and all(r["relation"] == "viewer" for r in result)
+        )
+
+    def test_first_page_honors_page_size(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = self.feature_under_test()
+        rows = run_query("paginated_tuple_store", self.valid_credentials()["paginated_tuple_store"], feat)
+        assert [(r["object_id"], r["user"]) for r in rows] == [("doc1", "user:alice"), ("doc1", "user:bob")]
+
+    def test_second_page_via_cursor_token(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        feat = Feature("paginated_tuple_store__page2", options=Options(context={"cursor_token": "offset:2"}))
+        rows = run_query("paginated_tuple_store", self.valid_credentials()["paginated_tuple_store"], feat)
+        assert [(r["object_id"], r["user"]) for r in rows] == [("doc2", "user:carol"), ("doc3", "user:dave")]
+
+    def test_expand_paths_expands_group_userset(self) -> None:
+        """With expand_paths, the group userset is replaced by its members."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = dict(self.valid_credentials()["paginated_tuple_store"])
+        slot["expand_paths"] = ["member"]
+        slot["page_size"] = 100
+        feat = self.feature_under_test()
+        rows = run_query("paginated_tuple_store", slot, feat)
+        users = {r["user"] for r in rows}
+        assert "user:erin" in users and "user:frank" in users
+        assert "group:eng#member" not in users
+
+    def test_without_expand_paths_group_ref_passes_through(self) -> None:
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = dict(self.valid_credentials()["paginated_tuple_store"])
+        slot["page_size"] = 100
+        feat = self.feature_under_test()
+        rows = run_query("paginated_tuple_store", slot, feat)
+        users = {r["user"] for r in rows}
+        assert "group:eng#member" in users
+        assert "user:erin" not in users
+
+    def test_unknown_tenant_raises_typed_error(self) -> None:
+        slot = dict(self.valid_credentials()["paginated_tuple_store"])
+        slot["tenant"] = "tenant_does_not_exist"
+        with pytest.raises(UnknownTenantError):
+            PaginatedTupleStoreReader._connect_from_slot(slot)
+
+    def test_cursor_token_with_non_cursor_style_rejected(self) -> None:
+        """The PaginationMixin cross-layer guard rejects cursor_token unless pagination_style is cursor-family.
+
+        pagination_style is narrowed to ``cursor`` here, so the only way to
+        violate the guard is to also bypass the credential narrowing; this test
+        instead confirms the happy path (cursor_token + cursor style) builds.
+        """
+        slot = dict(self.valid_credentials()["paginated_tuple_store"])
+        feat = Feature("paginated_tuple_store__cursor_ok", options=Options(context={"cursor_token": "offset:0"}))
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+        fs = FeatureSet()
+        fs.add(feat)
+        params = PaginatedTupleStoreReader.build_params(fs, slot)
+        assert params["cursor_token"] == "offset:0"
+
+    def test_malformed_cursor_token_rejected(self) -> None:
+        """A malformed cursor surfaces ``InvalidCredentialShape`` from ``load_data``.
+
+        Exercised directly against the reader (not through ``mloda.run_all``,
+        which wraps reader exceptions in a bare ``Exception``) so the typed
+        error contract is asserted at the reader boundary.
+        """
+        from mloda.core.abstract_plugins.components.feature_set import FeatureSet
+
+        slot = dict(self.valid_credentials()["paginated_tuple_store"])
+        feat = Feature("paginated_tuple_store__bad_cursor", options=Options(context={"cursor_token": "garbage"}))
+        fs = FeatureSet()
+        fs.add(feat)
+        with pytest.raises(InvalidCredentialShape):
+            PaginatedTupleStoreReader.load_data({"paginated_tuple_store": slot}, fs)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dev = [
     "mypy",
     "bandit",
 ]
-kg-rdf = ["rdflib>=7.0"]
-kg-embedded = ["networkx>=3.2"]
-kg-network-pg = ["kuzu>=0.4"]
+kg-rdf = ["rdflib>=7.0", "pyoxigraph>=0.4"]
+kg-embedded = ["networkx>=3.2", "igraph>=0.11"]
+kg-network-pg = ["kuzu>=0.4", "networkx>=3.2", "grand-cypher>=0.12"]
 kg-memory = ["networkx>=3.2"]
 kg-ontology = ["pyyaml>=6.0"]
 # Pure-stdlib families: extras intentionally empty so every family installs via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "mypy",
     "bandit",
 ]
-kg-rdf = ["rdflib>=7.0", "pyoxigraph>=0.4"]
+kg-rdf = ["rdflib>=7.0", "pyoxigraph>=0.5"]
 kg-embedded = ["networkx>=3.2", "igraph>=0.11"]
 kg-network-pg = ["kuzu>=0.4", "networkx>=3.2", "grand-cypher>=0.12"]
 kg-memory = ["networkx>=3.2"]

--- a/uv.lock
+++ b/uv.lock
@@ -899,7 +899,7 @@ requires-dist = [
     { name = "networkx", marker = "extra == 'kg-network-pg'", specifier = ">=3.2" },
     { name = "open-kgo", extras = ["kg-all"], marker = "extra == 'demo'" },
     { name = "open-kgo", extras = ["kg-rdf", "kg-embedded", "kg-network-pg", "kg-memory", "kg-rest", "kg-lineage", "kg-codebuild", "kg-saas", "kg-citation", "kg-ontology"], marker = "extra == 'kg-all'" },
-    { name = "pyoxigraph", marker = "extra == 'kg-rdf'", specifier = ">=0.4" },
+    { name = "pyoxigraph", marker = "extra == 'kg-rdf'", specifier = ">=0.5" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml", marker = "extra == 'kg-ontology'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'kg-rdf'", specifier = ">=7.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -237,6 +237,31 @@ wheels = [
 ]
 
 [[package]]
+name = "grand-cypher"
+version = "1.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "grandiso" },
+    { name = "lark" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/78/5c74812e3f1bc9942f88a0e5f8783113764dbcfda67a47e06dc601c63dc0/grand_cypher-1.0.1.tar.gz", hash = "sha256:576990dbc070d12ba49d39447c83515e8a62dbb1ef83986c1ec7f6391240a3e7", size = 41402, upload-time = "2025-09-23T15:54:18.318Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/fb/e658eaa18dd9103f5a88e7610243584be35501231d7ccd0c3eff3357e932/grand_cypher-1.0.1-py3-none-any.whl", hash = "sha256:af769d1e8c3a9a657953adaf468fbfc9d632b0d34fd6d2965248607007ef51a4", size = 28695, upload-time = "2025-09-23T15:54:16.739Z" },
+]
+
+[[package]]
+name = "grandiso"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/65/c6/27400e2d81bd769ebe65c695cead44c8efb55ac3769826a01c9223d65709/grandiso-2.2.0.tar.gz", hash = "sha256:66f292d27328e13122065c7905ad0ac79c4649f69a35e7b98a3631654a0bf77c", size = 16277, upload-time = "2024-02-13T16:21:18.053Z" }
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -252,6 +277,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/77/7b3966d0b9d1d31a36ddf1746926a11dface89a83409bf1483f0237aa758/idna-3.15.tar.gz", hash = "sha256:ca962446ea538f7092a95e057da437618e886f4d349216d2b1e294abfdb65fdc", size = 199245, upload-time = "2026-05-12T22:45:57.011Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl", hash = "sha256:048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8", size = 72340, upload-time = "2026-05-12T22:45:55.733Z" },
+]
+
+[[package]]
+name = "igraph"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "texttable" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/be/56bef1919005b4caf1f71522b300d359f7faeb7ae93a3b0baa9b4f146a87/igraph-1.0.0.tar.gz", hash = "sha256:2414d0be2e4d77ee5357807d100974b40f6082bb1bb71988ec46cfb6728651ee", size = 5077105, upload-time = "2025-10-23T12:22:50.127Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/03/3278ad0ceb3ea0e84d8ae3a85bdded4d0e57853aeb802a200feb43847b93/igraph-1.0.0-cp39-abi3-macosx_10_15_x86_64.whl", hash = "sha256:c2cbc415e02523e5a241eecee82319080bf928a70b1ba299f3b3e25bf029b6d4", size = 2257415, upload-time = "2025-10-23T12:22:27.246Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bc/6281ec7f9baaf71ee57c3b1748da2d3148d15d253e1a03006f204aa68ca5/igraph-1.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a27753cd80680a8f676c2d5a467aaa4a95e510b30748398ec4e4aeb982130e8", size = 2048555, upload-time = "2025-10-23T12:22:29.49Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/38/3cd6428a4ed4c09a56df05998438e7774fd1d799ee4fb8fc481674f5f7fc/igraph-1.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a55dc3a2a4e3fc3eba42479910c1511bfc3ecb33cdf5f0406891fd85f14b5aee", size = 5314141, upload-time = "2025-10-23T12:22:31.023Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/da/dd2867c25adbb41563720f14b5fc895c98bf88be682a3faff4f7b3118d2a/igraph-1.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d04c2c76f686fb1f554ee35dfd3085f5e73b7965ba6b4cf06d53e66b1955522", size = 5683134, upload-time = "2025-10-23T12:22:32.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/40/243c118d34ab80382d7009c4dcb99b887384c3d2ce84d29eeac19e2a007a/igraph-1.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:f2b52dc1757fff0fed29a9f7a276d971a11db4211569ed78b9eab36288dfcc9d", size = 6211583, upload-time = "2025-10-23T12:22:34.238Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/b7/88f433819c54b496cb0315fce28e658970cb20ff5dbd52a5a605ce2888de/igraph-1.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:05c79a2a8fca695b2f217a6fa7f2549f896f757d4db41be32a055400cb19cc30", size = 6594509, upload-time = "2025-10-23T12:22:35.831Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5d/8f7f6f619d374e959aa3664ebc4b24c10abc90c2e8efbed97f2623fadaf5/igraph-1.0.0-cp39-abi3-win32.whl", hash = "sha256:c2bce3cd472fec3dd9c4d8a3ea5b6b9be65fb30edf760beb4850760dd4f2d479", size = 2725406, upload-time = "2025-10-23T12:22:37.588Z" },
+    { url = "https://files.pythonhosted.org/packages/af/77/a85b3745cf40a0572bae2de8cd9c2a2a8af78e5cf3e880fc0a249114e609/igraph-1.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:faeff8ede0cf15eb4ded44b0fcea6e1886740146e60504c24ad2da14e0939563", size = 3221663, upload-time = "2025-10-23T12:22:39.404Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/7e/5df541c37bdf6493035e89c22bd53f30d99b291bcda6c78e9a8afeecec2b/igraph-1.0.0-cp39-abi3-win_arm64.whl", hash = "sha256:b607cafc24b10a615e713ee96e58208ef27e0764af80140c7cc45d4724a3f2df", size = 2785701, upload-time = "2025-10-23T12:22:41.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/bf1d4dbbc9123435b3ca14bb608b243a50a4f158ecea564bf196715248d9/igraph-1.0.0-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:3189c1a8e8a8f58009f3f729040eb3701254d074ed37245691d529869ec940c5", size = 2246636, upload-time = "2025-10-23T12:22:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/59/ac/28482f2af45cc0a0ca88a69d17a6ea694f58bdbd22cc876e7273a0379282/igraph-1.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ebe9502689b946301584b3cfacdbc70c58c4d664d804e39b6daa31be5c20bf46", size = 2036101, upload-time = "2025-10-23T12:22:43.957Z" },
+    { url = "https://files.pythonhosted.org/packages/56/80/806a093df1d1ddc3b30d0418b1ee56388ae7018f8ae288677ee2b3a1abaf/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:f117683108c54330d6dc67a708e3724c13c9989885122a29781296872989a222", size = 3053403, upload-time = "2025-10-23T12:22:45.573Z" },
+    { url = "https://files.pythonhosted.org/packages/56/bf/cf7aeff230a4368c0b8bc6b02f3ea27db41db33714b51e1e8a7c1458f31b/igraph-1.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:077dbff0edb8b4ce0f9fefdf325200346d9d5db02de31872b41743de08e67a16", size = 3262472, upload-time = "2025-10-23T12:22:47.248Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ca/dbc06072d5eea402a6dc81f387afb1b7e0c415f1d8a75232943fc4d1bfdb/igraph-1.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:fe7c693b2a84a4e03ca31e65aa05a2ecd8728137fa9909ccbf6453b4200b856d", size = 3218861, upload-time = "2025-10-23T12:22:48.46Z" },
 ]
 
 [[package]]
@@ -325,6 +375,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/77/13/df6e06a7d7506743c3a6cfbe50ee3f9d3fc58228e2a2fcbe7e74e7c17b00/kuzu-0.11.3-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:86be7d113e4e2c6761b1701079af8aeffc04c6981517f2d6aa393e883cc46036", size = 7615882, upload-time = "2025-10-10T13:36:28.215Z" },
     { url = "https://files.pythonhosted.org/packages/32/85/c52c3b167edcc67da3b8788a20a2fb5b4f045060cbe1aed6121ce3ce83d3/kuzu-0.11.3-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d72ebd88e231b562e7a60ff88d200825d53e78a681bddd7f8d77b78126a5060c", size = 6798657, upload-time = "2025-10-10T13:36:29.935Z" },
     { url = "https://files.pythonhosted.org/packages/06/be/5b4ff168718165c2ff5848ab79e22ecce72ad00522afee6820d390cb0753/kuzu-0.11.3-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64c7ec822906bdee154eb38d93e64f184d8f94b30bbeaceaa252725f2b9efab3", size = 7620394, upload-time = "2025-10-10T13:36:31.69Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -773,10 +832,13 @@ dependencies = [
 
 [package.optional-dependencies]
 demo = [
+    { name = "grand-cypher" },
+    { name = "igraph" },
     { name = "kuzu" },
     { name = "marimo" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyoxigraph" },
     { name = "pyyaml" },
     { name = "rdflib" },
 ]
@@ -790,13 +852,17 @@ dev = [
     { name = "uv" },
 ]
 kg-all = [
+    { name = "grand-cypher" },
+    { name = "igraph" },
     { name = "kuzu" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "pyoxigraph" },
     { name = "pyyaml" },
     { name = "rdflib" },
 ]
 kg-embedded = [
+    { name = "igraph" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
@@ -805,18 +871,24 @@ kg-memory = [
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 kg-network-pg = [
+    { name = "grand-cypher" },
     { name = "kuzu" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 kg-ontology = [
     { name = "pyyaml" },
 ]
 kg-rdf = [
+    { name = "pyoxigraph" },
     { name = "rdflib" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "bandit", marker = "extra == 'dev'" },
+    { name = "grand-cypher", marker = "extra == 'kg-network-pg'", specifier = ">=0.12" },
+    { name = "igraph", marker = "extra == 'kg-embedded'", specifier = ">=0.11" },
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
     { name = "mloda", specifier = ">=0.8.0" },
@@ -824,8 +896,10 @@ requires-dist = [
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },
     { name = "networkx", marker = "extra == 'kg-memory'", specifier = ">=3.2" },
+    { name = "networkx", marker = "extra == 'kg-network-pg'", specifier = ">=3.2" },
     { name = "open-kgo", extras = ["kg-all"], marker = "extra == 'demo'" },
     { name = "open-kgo", extras = ["kg-rdf", "kg-embedded", "kg-network-pg", "kg-memory", "kg-rest", "kg-lineage", "kg-codebuild", "kg-saas", "kg-citation", "kg-ontology"], marker = "extra == 'kg-all'" },
+    { name = "pyoxigraph", marker = "extra == 'kg-rdf'", specifier = ">=0.4" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pyyaml", marker = "extra == 'kg-ontology'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'kg-rdf'", specifier = ">=7.0" },
@@ -938,6 +1012,46 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+]
+
+[[package]]
+name = "pyoxigraph"
+version = "0.5.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/fd/21f10f55194b527348005c54ea87612d1af795be63db19e0abe6530d9920/pyoxigraph-0.5.8.tar.gz", hash = "sha256:c9fd2e3537fdd96d3895af259aefdc6f40b86a3f969d68fd3fe3cbf9f707f462", size = 5305516, upload-time = "2026-04-28T20:43:18.665Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/6c/422277e8d788e0b706928f1b25aa582fd3581b7f1f052ef258d10f5099e0/pyoxigraph-0.5.8-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:a14fce7014892b2b85b0350903197cccdab9d4c8b889c77c6e748426a7cd5c5b", size = 7702836, upload-time = "2026-04-28T20:42:13.216Z" },
+    { url = "https://files.pythonhosted.org/packages/59/d8/fad202f86e9bcd7ea2512d0d086405f5b77b47b634640a61e99ad5e755ad/pyoxigraph-0.5.8-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:3aecd4f5bde22c4cae03b398b0144411745940787e174e0d2690abbb486c4688", size = 8220927, upload-time = "2026-04-28T20:42:15.744Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/49/1cfb1cbbd60164b543547a5c538fe7ab46bce461764a2a19daeae33f404a/pyoxigraph-0.5.8-cp310-cp310-win_amd64.whl", hash = "sha256:14e34a8d83b2b3f1abb99de322bd31f158d1a59f690317201e7cf43b297523c3", size = 5446377, upload-time = "2026-04-28T20:42:17.329Z" },
+    { url = "https://files.pythonhosted.org/packages/17/9f/b5eb3254b63661b9f7f7d12bded5e70148fb5d56bac0fae3b529ce2cdb16/pyoxigraph-0.5.8-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:164b9b41769cdc5ac93ff37f1dd418fe2970a839e6bb283a5f095224a10bae3f", size = 7702679, upload-time = "2026-04-28T20:42:19.24Z" },
+    { url = "https://files.pythonhosted.org/packages/41/dd/8ad52b1ae147c948bd2f217fc9c71cd02211a5570dc9e43ecb04b19cf3fa/pyoxigraph-0.5.8-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:d7aa10a7c3e00cfccae819bbf040cef396db5304d5ea9890317fd8031e844684", size = 8220803, upload-time = "2026-04-28T20:42:21.13Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/3e/1c2e36999ac1884fd4a335c6c6c7aa68e3cb0038599386f7acb75dd0374c/pyoxigraph-0.5.8-cp311-cp311-win_amd64.whl", hash = "sha256:b43865ffdbc86bf8a48d3184272a5e3b1097c5105d9a4f444a6dda1e76763f88", size = 5446937, upload-time = "2026-04-28T20:42:23.056Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/58/3bd1419d9264b6027dc758340007951a7b3842dcb7f420c53da62ded33af/pyoxigraph-0.5.8-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:fa823ed87c34d21331f17c3ff6cd62b2ef188b945b70d741f0a7429d671aa3c9", size = 7704079, upload-time = "2026-04-28T20:42:25.362Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/d0/8ef9a7582373e106a4159a7ac59f908a92f6fa1ea776b8bd2289fdebd764/pyoxigraph-0.5.8-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:567618c3595c27caa64dff479a679592bc455af6b4afc3b24ca120fb2eed8327", size = 8224731, upload-time = "2026-04-28T20:42:27.323Z" },
+    { url = "https://files.pythonhosted.org/packages/61/88/68ae76c58171bde3c66b6c019e5b6367f83783a9a44fc5a95bf6b2928f58/pyoxigraph-0.5.8-cp312-cp312-win_amd64.whl", hash = "sha256:7903f0168f6313cacbf0815221dbedbb54606f172a6a3c4623caba42ae64702c", size = 5449186, upload-time = "2026-04-28T20:42:29.498Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/02/1759261c7b20c4671a6837083de9ded8122ee6a4cd9b3e9efdbf2ce3dbab/pyoxigraph-0.5.8-cp312-cp312-win_arm64.whl", hash = "sha256:07153608e35514368a157f7427aef6d9be4fcb3b32a0b2edc0c849d85627d981", size = 5073598, upload-time = "2026-04-28T20:42:31.32Z" },
+    { url = "https://files.pythonhosted.org/packages/11/90/6bc32bc00d49b86047cc42b0afbdd804da2e0f8d512c14c35d3eef1095c0/pyoxigraph-0.5.8-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0bcaa1b7a4c5a2521f5f0fe4d837f29ddd40d3be1ad26e4220ac839eea657a52", size = 7705136, upload-time = "2026-04-28T20:42:32.893Z" },
+    { url = "https://files.pythonhosted.org/packages/82/b2/98dc78bbe6c9fe407c04dcf92281eaa58e5b3a9d5a5d31a62b09d004d6b4/pyoxigraph-0.5.8-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:bd1cfedd6bc7ea0502bb86449881afa4b9b89015aae6608cedcb4e1fd0749924", size = 8225560, upload-time = "2026-04-28T20:42:34.856Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/23/562c411d1c55a1e08a645b569980c97f24b8b8effbbaec56a94702e08056/pyoxigraph-0.5.8-cp313-cp313-win_amd64.whl", hash = "sha256:5236e59f26ff1606eb05941df24b9d470a183d11bc904a5722aac23aa8dd1b01", size = 5449722, upload-time = "2026-04-28T20:42:37.186Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/18/50e3793b65965a8006f45b8c01839b6f280e3dbcc82098b62108a6d3510f/pyoxigraph-0.5.8-cp313-cp313-win_arm64.whl", hash = "sha256:d324d334379b361646952da7d82cfc0bfb1e411f0e8a1f25f78a301c3bf41137", size = 5074183, upload-time = "2026-04-28T20:42:38.722Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/c7/c13220b5e9e12dbcbb8f8c221ae892854e28e600658db7c69d1cfd5bdf1e/pyoxigraph-0.5.8-cp313-cp313t-win_amd64.whl", hash = "sha256:a40b7449d5406aa1c0f6a3511191c484b333f7debaac48e3fcfc804b529dcb84", size = 5447293, upload-time = "2026-04-28T20:42:40.675Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/19/640f52f219eda8fa7d40498eaad2b7392e913cea37c31d4389b74037509f/pyoxigraph-0.5.8-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:914355bdd92455e5538938aeeb15dedfe80ceb2bf7d576e67e00abc3c7a23ce1", size = 7701324, upload-time = "2026-04-28T20:42:42.329Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/80/9fa0bd17d17a73e2a14359ba9135fd1721d4d64fe3b38d8625e78a02a484/pyoxigraph-0.5.8-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:97f9589fdf8b02acd9342b71f118352740012ae97f559eed65c3452d2555ca26", size = 8220766, upload-time = "2026-04-28T20:42:44.07Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f1/e865421c48252992105fda37b78ba82be50abeeee89096b1fb87f56325d0/pyoxigraph-0.5.8-cp314-cp314-win_amd64.whl", hash = "sha256:23d89e6aa3810084b3d9e405a13440e8196d55c3df5d747d4f0307331ee61f11", size = 5447875, upload-time = "2026-04-28T20:42:46.095Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/61/d21ed60790aa0a373d8e7761edb042cd494527a7f9ad9d9ff05a276fe8ed/pyoxigraph-0.5.8-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:598e409ddf0440734259ff5d30a9d20eb1867c635031188c1cc923e8773289ae", size = 7694353, upload-time = "2026-04-28T20:42:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/83/3e/f41c3fda4b67d1edd534cbc75529071f7e64359404f54e70cb99f4591f1d/pyoxigraph-0.5.8-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:8a76d9473ccf0a866443ce2be384ac83b97113345a2929a520c7aab583ce7364", size = 8218478, upload-time = "2026-04-28T20:42:50.147Z" },
+    { url = "https://files.pythonhosted.org/packages/57/dd/53be335381c373816e290f445325a7d444f1dbb1d98a00b15b5c93775128/pyoxigraph-0.5.8-cp314-cp314t-win_amd64.whl", hash = "sha256:9e81f6afebcc115c9f43d8b86869f5167f0d52eccb8ca3e5d359905e9a989fad", size = 5441788, upload-time = "2026-04-28T20:42:52.137Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/32/9e2dacd0ee4a88e6fb190ac97d7f4832829451e48f993027359fe32f3078/pyoxigraph-0.5.8-cp38-abi3-macosx_10_14_x86_64.whl", hash = "sha256:b925ab74ad7cecab359896964278448d45f777fde94b22df99808f2c52e18376", size = 6328777, upload-time = "2026-04-28T20:42:54.039Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/ec/14ec2530f6b96df3199afc0cf67fd79492106530d740d65517fb81d80ec8/pyoxigraph-0.5.8-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:88dac8561fbe1bcfe3c2193f5526bc297a3fd03545cd94da6581f7d12d788628", size = 5805509, upload-time = "2026-04-28T20:42:56.206Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/eab9c5729e31f5e64b7bc54f2be3a6581a446f01690c7c66e9bb9c5f598c/pyoxigraph-0.5.8-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:af7e42484d8e636ea9dfd12e39862b84067624b62be59f21c16c7e36fff74dfc", size = 7706347, upload-time = "2026-04-28T20:42:57.91Z" },
+    { url = "https://files.pythonhosted.org/packages/12/71/7be1d3cfe9fa4e31eb5bea0286e099d24ded457bd2b63da192fe3af72ab8/pyoxigraph-0.5.8-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:108f6a8c7129ed678bdf12906328e9fea38a88c604b55677b5cb32a3f68daede", size = 8226169, upload-time = "2026-04-28T20:42:59.46Z" },
+    { url = "https://files.pythonhosted.org/packages/74/5f/a7165e1d8b9d3797a51a78d190da0a6d3933eccb58f5b502e412ef4ed5ad/pyoxigraph-0.5.8-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:bc943aebf424e1cd4b00b46f732078d028c365edcb3fc097e802ace8a612fb75", size = 8889357, upload-time = "2026-04-28T20:43:01.206Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/46/782e87e77f1a41cba553823f3fb39c2ed77bfb4ae4a39ed68f946a373c48/pyoxigraph-0.5.8-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a6d1bc051ea2676495efc25931bd309efb830199150d72948c1c14e94624af8a", size = 9433564, upload-time = "2026-04-28T20:43:04.103Z" },
+    { url = "https://files.pythonhosted.org/packages/40/79/3704d8b2013d8de7cc30ee3b12ad142d23e9c779523b0f821114e684aa04/pyoxigraph-0.5.8-cp38-abi3-win_amd64.whl", hash = "sha256:901e711f590945295214868c9ad01118ae89da610fabd4deeef2665e0ecda256", size = 5448135, upload-time = "2026-04-28T20:43:06.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/88/b881b7a8dc92ae6fb302bcb18f18b15c1782a3c86557a9c0e55bcdb9a146/pyoxigraph-0.5.8-cp38-abi3-win_arm64.whl", hash = "sha256:eb39a617dd0573f2e3a37a86614eaeac974caf77db1243d3fe7148841d0329c9", size = 5072423, upload-time = "2026-04-28T20:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f7/748e1229f933012905114cec4d484b1d799f374b6b94e06c209cd103aab1/pyoxigraph-0.5.8-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:ede43c55336fe8bae1607cb2d1586ac3fe29dcf63761616d3aee45cb42395b22", size = 7703814, upload-time = "2026-04-28T20:43:13.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/0f/6e1bfb7c642c3d0a81e57cbc8b1b539cc7d2fb451eccd975705f5a0978ab/pyoxigraph-0.5.8-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d42dfd064be0a3f66c2301a0c8501d2079b570625d279e4aabba0e10a9102151", size = 8220892, upload-time = "2026-04-28T20:43:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/d6/69b9e9a9a1bd7124391cae5f71bf3063c30708ea563dad3674dfecb9db98/pyoxigraph-0.5.8-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:9676f2adad8468cdceb05a72a7b2bcc37683af3ddb37f595c370946f7d9f1543", size = 5446016, upload-time = "2026-04-28T20:43:17.016Z" },
 ]
 
 [[package]]
@@ -1201,6 +1315,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/96/5b/496f8abebd10c3301129abba7ddafd46c71d799a70c44ab080323987c4c9/stevedore-5.6.0.tar.gz", hash = "sha256:f22d15c6ead40c5bbfa9ca54aa7e7b4a07d59b36ae03ed12ced1a54cf0b51945", size = 516074, upload-time = "2025-11-20T10:06:07.264Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/40/8561ce06dc46fd17242c7724ab25b257a2ac1b35f4ebf551b40ce6105cfa/stevedore-5.6.0-py3-none-any.whl", hash = "sha256:4a36dccefd7aeea0c70135526cecb7766c4c84c473b1af68db23d541b6dc1820", size = 54428, upload-time = "2025-11-20T10:06:05.946Z" },
+]
+
+[[package]]
+name = "texttable"
+version = "1.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/dc/0aff23d6036a4d3bf4f1d8c8204c5c79c4437e25e0ae94ffe4bbb55ee3c2/texttable-1.7.0.tar.gz", hash = "sha256:2d2068fb55115807d3ac77a4ca68fa48803e84ebb0ee2340f858107a36522638", size = 12831, upload-time = "2023-10-03T09:48:12.272Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/99/4772b8e00a136f3e01236de33b0efda31ee7077203ba5967fcc76da94d65/texttable-1.7.0-py2.py3-none-any.whl", hash = "sha256:72227d592c82b3d7f672731ae73e4d1f88cd8e2ef5b075a7a7f01a23a3743917", size = 10768, upload-time = "2023-10-03T09:48:10.434Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes the "complete each KG family" research from [TomKaltofen/open-kgo#16](https://github.com/TomKaltofen/open-kgo/issues/16): every one of the 9 KG connector families now ships **two** concrete plugins instead of one, so each `<Family>Reader` base is exercised by more than a single backend. All run with **no Docker, no network, no external services** (in-memory libs or static local fixtures), per the family testing policy.

## What's added (one second concrete per family)

**New-surface plugins** — honor family-level keys the first concrete narrows/strips (the high-value picks):

| Family | New plugin | Surface it newly exercises |
|---|---|---|
| `code_build` | `SpdxSbomReader` | Walks the SPDX `DEPENDS_ON` graph, honoring `TraversalMixin` (`lineage_direction`/`upstream_depth`/`downstream_depth`) that CycloneDX strips |
| `rest_public` | `FileFixturePagedRestReader` | `pagination_style=page` + `page_size` (cursor concrete drops these) |
| `citation_rest` | `PaginatedCitationReader` | cursor pagination + `page_size` + `cursor_token` + `entity_type` |
| `agent_memory` | `GraphWalkMemoryReader` | `retrieval_mode=graph` (lexical concrete narrows to `lexical`) |
| `saas_authz` | `PaginatedTupleStoreReader` | cursor pagination + `expand_paths` (structural group-userset expansion) |

**Backend-variety plugins** — same family contract, second substrate (prove the base generalizes):

| Family | New plugin | Substrate |
|---|---|---|
| `network_pg` | `GrandCypherReader` | openCypher over NetworkX (`grand-cypher`) |
| `rdf` | `OxigraphSparqlReader` | `pyoxigraph` embedded SPARQL store |
| `embedded` | `IGraphEmbeddedReader` | `python-igraph` |
| `lineage` | `OpenLineageReader` | OpenLineage run-event JSON (stdlib) |

## Dependencies

Three new third-party deps, scoped to the matching `kg-<family>` extra only: `pyoxigraph` (`kg-rdf`), `igraph` (`kg-embedded`), `grand-cypher` (`kg-network-pg`). **SPDX and OpenLineage parse static JSON with stdlib — no new dependency** (matching the existing CycloneDX/dbt pattern; the issue's `spdx-tools`/`sqllineage` candidates were intentionally skipped in favor of the lighter stdlib path).

## Tests & infra

- Each concrete subclasses its per-family `*ContractTestBase` (inheriting the full universal + per-family contract suite) plus behavior-specific tests; per-concrete fixtures added.
- Shared `parse_offset_cursor` helper in `mixins.py` (used by the two cursor-paginating readers); mtime-cached `load_oxigraph_store` loader in `fixtures.py` (sibling of `load_rdf_graph`), cleared in `conftest.py`.
- Family `README.md` map + each family `__init__.py` note updated to reflect the second concrete and the surface it adds (and to correct now-stale "only concrete plugin" / "graph raises NotImplementedError" / "dependencies not walked" claims).

## Verification

`tox` green on python310: **801 passed, 52 skipped**, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
