### PR TITLE
chore: pin conventional-changelog-conventionalcommits to 9.3.1

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
           npm install -g semantic-release@v24.2.1 \
             conventional-changelog-cli \
-            conventional-changelog-conventionalcommits \
+            conventional-changelog-conventionalcommits@9.3.1 \
             @semantic-release/changelog \
             @semantic-release/exec \
             @semantic-release/git \


### PR DESCRIPTION
## Problem

Release notes generated by semantic-release come out empty (version header only, no Features / Bug Fixes / etc. sections). Example: mloda-ai/open-kgo release `0.2.1`.

Root cause is an unpinned transitive dependency. The release workflow installs `conventional-changelog-conventionalcommits` unpinned. On 2026-06-26 that package published a breaking major (v10) which:

- replaced the `hidden` commit-type property with a new `effect` property, so section/visibility config in `.releaserc.yaml` is silently ignored, and
- replaced Handlebars templates/partials with render functions (via `@conventional-changelog/template`, consumed by `conventional-changelog-writer@9`).

`@semantic-release/release-notes-generator@14` (latest) still depends on `conventional-changelog-writer@^8` (the Handlebars writer) and is tested (devDependency) against `conventional-changelog-conventionalcommits@9.3.1`. When the unpinned install resolves v10, writer 8 cannot consume the v10 preset's render functions, so it renders nothing. This affects all commit types, not just `chore`.

Migrating forward to the v10 preset is not currently possible in a supported way: no published `@semantic-release/release-notes-generator` depends on `conventional-changelog-writer@9`, so nothing in the semantic-release chain speaks the render-function protocol v10 emits.

## Fix

Pin `conventional-changelog-conventionalcommits@9.3.1` in the release workflow, the exact version `release-notes-generator@14` is tested against. This restores populated release notes and keeps a supported dependency combination.

## Scope

Org-wide regression. Identical PRs are being opened in `mloda`, `mloda-registry`, `mloda-plugin-template`, and `mloda-plugin-govdata`.
