### PR TITLE
fix: exclude test packages from the wheel, make mloda-testing dev-only, add pip quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,31 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 
 ## Quickstart
 
-Install the connectors and run a SPARQL query against the Turtle sample shipped in this repo:
+Install the connectors from PyPI and run a SPARQL query against a small Turtle file:
 
 ```bash
-uv sync --extra kg-all
+pip install "open-kgo[kg-all]"
 ```
+
+(Working from a clone instead? `uv sync --extra kg-all`, see [Development setup](#development-setup).)
 
 ```python
 from pathlib import Path
 
 from mloda.user import DataAccessCollection, Feature, Options, mloda
 
-import open_kgo.feature_groups.kg.rdf.rdflib_sparql as rdf_mod
+# Importing the plugin module registers the rdflib_sparql feature group.
+import open_kgo.feature_groups.kg.rdf.rdflib_sparql  # noqa: F401
 from open_kgo.compute_frameworks.python_dict_kg_framework import KgPythonDictFramework
 
-# Point at any RDF file. Here: the Turtle sample shipped in this repo.
-ttl = Path(rdf_mod.__file__).parent / "tests" / "fixtures" / "sample.ttl"
+# Point at any RDF file. Here: a three-triple sample written on the spot.
+ttl = Path("sample.ttl")
+ttl.write_text(
+    "@prefix foaf: <http://xmlns.com/foaf/0.1/> .\n"
+    "@prefix ex: <http://example.org/> .\n"
+    "ex:alice foaf:knows ex:bob .\n"
+    "ex:bob foaf:knows ex:carol .\n"
+)
 
 feature = Feature(
     "rdflib_sparql__knows",
@@ -78,7 +87,7 @@ Swap `rdflib_sparql` for any of the nine connector families below: same `Feature
 
 See [`open_kgo/feature_groups/kg/README.md`](open_kgo/feature_groups/kg/README.md) for the full family map, the plugin anatomy, and what the prototype does and does not validate.
 
-Install all KG extras with: `uv sync --extra kg-all`.
+Install all KG extras with: `pip install "open-kgo[kg-all]"` (from a clone: `uv sync --extra kg-all`).
 
 > **One feature per call.** KG readers dispatch a single feature per load: every
 > reader rejects a multi-feature `FeatureSet` rather than silently labelling all
@@ -127,7 +136,7 @@ The solver is pure Python (no numpy) with an optional numba JIT kernel that give
 | L2 — SemanticField | Continuous entity scoring via DC circuit model | Built |
 | L3 — Discovery Engine | Guided multi-hop traversal by field strength | Planned |
 
-Install: `uv sync --extra kg-semantic-field`
+Install: `pip install "open-kgo[kg-semantic-field]"` (from a clone: `uv sync --extra kg-semantic-field`)
 
 Full visual explainer: [`demo/semantic_field_explainer.html`](demo/semantic_field_explainer.html) — open in any browser, no server needed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ description = "Open Knowledge Graphs and Ontologies plugin for mloda."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "tomkaltofen@mloda.ai" }]
-dependencies = ["mloda>=0.8.0", "mloda-testing>=0.3.1"]
+dependencies = ["mloda>=0.8.0"]
 requires-python = ">=3.10"
 # No `License ::` trove classifier: `license` above is an SPDX expression
 # (PEP 639) and setuptools rejects both together.
@@ -35,6 +35,8 @@ Repository = "https://github.com/mloda-ai/open-kgo"
 Issues = "https://github.com/mloda-ai/open-kgo/issues"
 
 [project.optional-dependencies]
+# mloda-testing backs the in-repo contract harness (open_kgo/**/tests/), which
+# is excluded from the wheel, so it is a dev-only dependency.
 dev = [
     "tox",
     "tox-uv",
@@ -43,6 +45,7 @@ dev = [
     "ruff",
     "mypy",
     "bandit",
+    "mloda-testing>=0.3.1",
 ]
 kg-rdf = ["rdflib>=7.0", "pyoxigraph>=0.5.9"]
 kg-embedded = ["networkx>=3.2", "igraph>=0.11"]
@@ -65,6 +68,9 @@ demo = ["marimo", "open-kgo[kg-all]"]
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["open_kgo*"]
+# The in-repo test contract harness stays out of the wheel: its fixtures are
+# not packaged, so shipping the test modules alone would be a broken artifact.
+exclude = ["*.tests", "*.tests.*"]
 
 # PEP 561 marker so the `Typing :: Typed` classifier is honoured (downstream
 # type-checkers otherwise ignore this package's inline types).

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -220,7 +220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -828,7 +828,6 @@ version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mloda" },
-    { name = "mloda-testing" },
 ]
 
 [package.optional-dependencies]
@@ -845,6 +844,7 @@ demo = [
 ]
 dev = [
     { name = "bandit" },
+    { name = "mloda-testing" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -896,7 +896,7 @@ requires-dist = [
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
     { name = "mloda", specifier = ">=0.8.0" },
-    { name = "mloda-testing", specifier = ">=0.3.1" },
+    { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.1" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },
     { name = "networkx", marker = "extra == 'kg-memory'", specifier = ">=3.2" },
@@ -1190,7 +1190,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Post-release cleanup after the first PyPI release (0.2.1). Three packaging issues, one fix each:

- The published wheel shipped 67 test modules (the in-repo contract harness under `open_kgo/**/tests/`) without their fixtures. `packages.find` now excludes `*.tests` / `*.tests.*`, so a clean build ships 66 production files and zero test packages.
- `mloda-testing` was a hard runtime dependency but is only imported by test code (`tests/test_mloda_imports.py` and the contract harness). It moves to the `dev` extra; downstream installs now pull only `mloda`. Every tox env installs `dev`, so the harness still runs in CI.
- The README quickstart had no pip install path and pointed at a Turtle fixture that never shipped in the wheel. It now opens with `pip install "open-kgo[kg-all]"` and writes its three-triple sample inline, so it works without cloning the repo. The other install one-liners gained pip variants too.

`uv.lock` is re-locked for the dependency move (plus benign marker refreshes; `uv lock --check` passes).

## Verification

- Built the wheel locally from a clean tree: 66 files, 0 test packages, `Requires-Dist: mloda>=0.8.0` only.
- Installed the wheel with the `kg-rdf` extra into a clean venv and ran the README quickstart verbatim: returns the two expected `foaf:knows` rows.
- `tox`: 1008 passed, 57 skipped; ruff format, ruff check, mypy --strict, bandit all green.

Note for reviewers: a locally stale `open_kgo.egg-info/` can feed test files back into a wheel via `include-package-data`; delete it before local builds. The release workflow builds from a fresh checkout, so published artifacts are unaffected.

## Review pass

Two independent reviews (Claude Opus subagent, codex) found no blocking issues. One pre-existing finding is spun out as a follow-up issue: the unconditional `import rdflib` in `open_kgo/feature_groups/kg/fixtures.py` breaks single-family installs without the `kg-rdf` extra.
