### PR TITLE
fix: defer rdflib import in kg/fixtures so non-RDF single-family installs work

### DIFF
--- a/open_kgo/feature_groups/kg/fixtures.py
+++ b/open_kgo/feature_groups/kg/fixtures.py
@@ -59,12 +59,11 @@ from xml.sax import SAXException  # nosec B406
 
 from open_kgo.feature_groups.kg.errors import FixtureLoadError
 
-# rdflib is imported lazily inside ``_read_rdf_graph_cached`` (mirroring the
-# deferred pyoxigraph / kuzu loaders below) so this shared module imports
-# without the ``kg-rdf`` extra; non-RDF families route through the JSON
-# loaders and must not pay the rdflib dependency. Only the type checker needs
-# the symbol at module scope: ``from __future__ import annotations`` keeps the
-# ``rdflib.Graph`` return annotations as strings at runtime.
+# rdflib is imported lazily inside ``_read_rdf_graph_cached`` (like the
+# deferred pyoxigraph / kuzu loaders) so non-RDF families can import this
+# shared module without the ``kg-rdf`` extra. Only the type checker needs the
+# symbol here; ``from __future__ import annotations`` keeps the ``rdflib.Graph``
+# return annotations as strings at runtime.
 if TYPE_CHECKING:
     import rdflib
 
@@ -231,8 +230,8 @@ def load_rdf_graph(connector_id: str, locator: Any) -> rdflib.Graph:
     (verified against rdflib 7.x) so the contract-test path that closes
     ``connect()``'s return survives the cache; ``add`` / ``remove`` calls
     would corrupt subsequent loads in the same process. The rdflib import is
-    deferred to call time (mirroring ``load_oxigraph_store`` /
-    ``load_kuzu_database``) so this module imports without the ``kg-rdf`` extra.
+    deferred to call time (like the oxigraph / kuzu loaders) so this module
+    imports without the ``kg-rdf`` extra.
     """
     return _load_cached(connector_id, locator, _read_rdf_graph_cached)
 
@@ -252,8 +251,8 @@ def _read_rdf_graph_cached(abs_path: str, mtime_ns: int) -> rdflib.Graph:
     plus ``ValueError`` / ``UnicodeDecodeError`` for bad bytes). Bare
     ``except Exception`` was previously used; narrowing it stops the
     block from masking programmer errors like ``AttributeError``. The rdflib
-    import is deferred here (not at module scope) so non-RDF families can
-    import this shared module without the ``kg-rdf`` extra installed.
+    import is deferred here so non-RDF families can import this module without
+    the ``kg-rdf`` extra.
     """
     import rdflib
     import rdflib.exceptions

--- a/open_kgo/feature_groups/kg/fixtures.py
+++ b/open_kgo/feature_groups/kg/fixtures.py
@@ -48,7 +48,7 @@ from __future__ import annotations
 import json
 from functools import lru_cache
 from pathlib import Path
-from typing import Any, Callable, Iterable, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Iterable, TypeVar
 from urllib.parse import urlparse
 
 # SAXException is used purely as a parent class for narrowing the
@@ -57,10 +57,16 @@ from urllib.parse import urlparse
 # the nosec comment documents the intent.
 from xml.sax import SAXException  # nosec B406
 
-import rdflib
-import rdflib.exceptions
-
 from open_kgo.feature_groups.kg.errors import FixtureLoadError
+
+# rdflib is imported lazily inside ``_read_rdf_graph_cached`` (mirroring the
+# deferred pyoxigraph / kuzu loaders below) so this shared module imports
+# without the ``kg-rdf`` extra; non-RDF families route through the JSON
+# loaders and must not pay the rdflib dependency. Only the type checker needs
+# the symbol at module scope: ``from __future__ import annotations`` keeps the
+# ``rdflib.Graph`` return annotations as strings at runtime.
+if TYPE_CHECKING:
+    import rdflib
 
 
 class _FixtureLoadProblem(Exception):
@@ -224,7 +230,9 @@ def load_rdf_graph(connector_id: str, locator: Any) -> rdflib.Graph:
     ``rdflib.Graph.close()`` is a no-op on the default Memory store
     (verified against rdflib 7.x) so the contract-test path that closes
     ``connect()``'s return survives the cache; ``add`` / ``remove`` calls
-    would corrupt subsequent loads in the same process.
+    would corrupt subsequent loads in the same process. The rdflib import is
+    deferred to call time (mirroring ``load_oxigraph_store`` /
+    ``load_kuzu_database``) so this module imports without the ``kg-rdf`` extra.
     """
     return _load_cached(connector_id, locator, _read_rdf_graph_cached)
 
@@ -243,8 +251,13 @@ def _read_rdf_graph_cached(abs_path: str, mtime_ns: int) -> rdflib.Graph:
     own ``ParserError`` lives under ``rdflib.exceptions.Error``;
     plus ``ValueError`` / ``UnicodeDecodeError`` for bad bytes). Bare
     ``except Exception`` was previously used; narrowing it stops the
-    block from masking programmer errors like ``AttributeError``.
+    block from masking programmer errors like ``AttributeError``. The rdflib
+    import is deferred here (not at module scope) so non-RDF families can
+    import this shared module without the ``kg-rdf`` extra installed.
     """
+    import rdflib
+    import rdflib.exceptions
+
     graph = rdflib.Graph()
     try:
         graph.parse(abs_path)

--- a/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
+++ b/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import subprocess
 import sys
 import textwrap
+from pathlib import Path
 
 
 def test_non_rdf_connector_imports_without_rdflib() -> None:
@@ -58,18 +59,16 @@ def test_non_rdf_connector_imports_without_rdflib() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_load_rdf_graph_still_works_with_rdflib_present(tmp_path: object) -> None:
+def test_load_rdf_graph_still_works_with_rdflib_present(tmp_path: Path) -> None:
     """The deferred import path still parses RDF when rdflib IS installed.
 
     Guards against a deferral that removes the top-level import but forgets to
     re-import inside the loader (which would surface as ``NameError`` on the
     first ``load_rdf_graph`` call rather than at import time).
     """
-    from pathlib import Path
-
     from open_kgo.feature_groups.kg.fixtures import load_rdf_graph
 
-    path = Path(str(tmp_path)) / "g.ttl"
+    path = tmp_path / "g.ttl"
     path.write_text('<urn:s> <urn:p> "o" .\n', encoding="utf-8")
     graph = load_rdf_graph("test", path)
     assert len(graph) == 1

--- a/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
+++ b/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
@@ -1,0 +1,75 @@
+"""Regression: the shared ``kg.fixtures`` module must import without ``kg-rdf``.
+
+``fixtures.py`` is imported by every file-backed connector family, including
+non-RDF ones (``agent_memory/networkx_memory``, ``saas_authz/...``). An
+unconditional top-level ``import rdflib`` therefore coupled every single-family
+install (e.g. ``open-kgo[kg-memory]``) to the ``kg-rdf`` extra, breaking those
+imports with ``ModuleNotFoundError: No module named 'rdflib'`` (issue #33).
+
+The rdflib environment IS present in this dev/test env (``kg-rdf`` is one of the
+installed extras), so absence is simulated in a child interpreter that blocks
+any ``import rdflib`` via a meta-path finder. The subprocess mirrors the issue's
+``python -c`` reproduction and keeps the blocker out of the parent test session.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_non_rdf_connector_imports_without_rdflib() -> None:
+    """A non-RDF connector and the shared fixtures module import with rdflib absent."""
+    code = textwrap.dedent(
+        """
+        import sys
+
+        class _BlockRdflib:
+            # Make any `import rdflib` / `import rdflib.<sub>` fail as if the
+            # kg-rdf extra were never installed.
+            def find_spec(self, name, path, target=None):
+                if name == "rdflib" or name.startswith("rdflib."):
+                    raise ModuleNotFoundError(f"No module named {name!r}")
+                return None
+
+        sys.modules.pop("rdflib", None)
+        sys.meta_path.insert(0, _BlockRdflib())
+
+        # Guard: confirm the simulated absence is actually in effect, otherwise
+        # the assertions below would pass trivially with rdflib importable.
+        try:
+            import rdflib  # noqa: F401
+        except ModuleNotFoundError:
+            pass
+        else:
+            raise SystemExit("test bug: rdflib should be unimportable here")
+
+        # The shared module and a non-RDF connector must import cleanly.
+        import open_kgo.feature_groups.kg.fixtures  # noqa: F401
+        import open_kgo.feature_groups.kg.agent_memory.networkx_memory  # noqa: F401
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_load_rdf_graph_still_works_with_rdflib_present(tmp_path: object) -> None:
+    """The deferred import path still parses RDF when rdflib IS installed.
+
+    Guards against a deferral that removes the top-level import but forgets to
+    re-import inside the loader (which would surface as ``NameError`` on the
+    first ``load_rdf_graph`` call rather than at import time).
+    """
+    from pathlib import Path
+
+    from open_kgo.feature_groups.kg.fixtures import load_rdf_graph
+
+    path = Path(str(tmp_path)) / "g.ttl"
+    path.write_text('<urn:s> <urn:p> "o" .\n', encoding="utf-8")
+    graph = load_rdf_graph("test", path)
+    assert len(graph) == 1

--- a/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
+++ b/open_kgo/feature_groups/kg/tests/test_fixtures_optional_rdflib.py
@@ -1,15 +1,10 @@
 """Regression: the shared ``kg.fixtures`` module must import without ``kg-rdf``.
 
-``fixtures.py`` is imported by every file-backed connector family, including
-non-RDF ones (``agent_memory/networkx_memory``, ``saas_authz/...``). An
-unconditional top-level ``import rdflib`` therefore coupled every single-family
-install (e.g. ``open-kgo[kg-memory]``) to the ``kg-rdf`` extra, breaking those
-imports with ``ModuleNotFoundError: No module named 'rdflib'`` (issue #33).
-
-The rdflib environment IS present in this dev/test env (``kg-rdf`` is one of the
-installed extras), so absence is simulated in a child interpreter that blocks
-any ``import rdflib`` via a meta-path finder. The subprocess mirrors the issue's
-``python -c`` reproduction and keeps the blocker out of the parent test session.
+``fixtures.py`` is imported by non-RDF connector families, so a top-level
+``import rdflib`` broke single-family installs like ``open-kgo[kg-memory]`` with
+``ModuleNotFoundError`` (issue #33). rdflib IS installed in this test env, so its
+absence is simulated in a subprocess that blocks the import via a meta-path
+finder.
 """
 
 from __future__ import annotations
@@ -27,8 +22,7 @@ def test_non_rdf_connector_imports_without_rdflib() -> None:
         import sys
 
         class _BlockRdflib:
-            # Make any `import rdflib` / `import rdflib.<sub>` fail as if the
-            # kg-rdf extra were never installed.
+            # Make any `import rdflib[...]` fail as if kg-rdf were not installed.
             def find_spec(self, name, path, target=None):
                 if name == "rdflib" or name.startswith("rdflib."):
                     raise ModuleNotFoundError(f"No module named {name!r}")
@@ -37,8 +31,7 @@ def test_non_rdf_connector_imports_without_rdflib() -> None:
         sys.modules.pop("rdflib", None)
         sys.meta_path.insert(0, _BlockRdflib())
 
-        # Guard: confirm the simulated absence is actually in effect, otherwise
-        # the assertions below would pass trivially with rdflib importable.
+        # Guard: fail loudly if the blocker is a no-op (else the test passes trivially).
         try:
             import rdflib  # noqa: F401
         except ModuleNotFoundError:
@@ -46,7 +39,6 @@ def test_non_rdf_connector_imports_without_rdflib() -> None:
         else:
             raise SystemExit("test bug: rdflib should be unimportable here")
 
-        # The shared module and a non-RDF connector must import cleanly.
         import open_kgo.feature_groups.kg.fixtures  # noqa: F401
         import open_kgo.feature_groups.kg.agent_memory.networkx_memory  # noqa: F401
         """
@@ -60,11 +52,10 @@ def test_non_rdf_connector_imports_without_rdflib() -> None:
 
 
 def test_load_rdf_graph_still_works_with_rdflib_present(tmp_path: Path) -> None:
-    """The deferred import path still parses RDF when rdflib IS installed.
+    """The deferred import path still parses RDF when rdflib is installed.
 
-    Guards against a deferral that removes the top-level import but forgets to
-    re-import inside the loader (which would surface as ``NameError`` on the
-    first ``load_rdf_graph`` call rather than at import time).
+    Guards against a deferral that drops the top-level import but forgets to
+    re-import inside the loader (a ``NameError`` on first call).
     """
     from open_kgo.feature_groups.kg.fixtures import load_rdf_graph
 


### PR DESCRIPTION
## Summary

`kg/fixtures.py` imported `rdflib` at module top. It is shared code imported by non-RDF connector families too, so a single non-RDF install like `open-kgo[kg-memory]` failed at import with `ModuleNotFoundError: No module named 'rdflib'`.

Fixes #33.

## Change

- Move `import rdflib` into `_read_rdf_graph_cached`, like the existing deferred `pyoxigraph` and `kuzu` loaders.
- Keep the `rdflib.Graph` annotations resolvable for `mypy --strict` via a `TYPE_CHECKING` guard (the module already uses `from __future__ import annotations`, so they stay strings at runtime).
- Add a regression test: a subprocess blocks `import rdflib` and asserts `kg.fixtures` and the non-RDF `agent_memory.networkx_memory` still import. A second test confirms `load_rdf_graph` still parses RDF when rdflib is present.

## Verification

`tox` green: 1010 passed, 57 skipped; `ruff`, `mypy --strict`, and `bandit` clean.
