### PR TITLE
feat(ontology): add DiscoveryEngine — Layer 3 beam search over EM field

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 | [Quickstart](#quickstart) | Run a SPARQL query against a shipped sample file in under a minute |
 | [The nine connector families](#the-nine-connector-families) | The core of this repo: a 9-family KG connector taxonomy with two plugins each |
 | [Semantic Fields — Layer 2](#semantic-fields--layer-2) | Continuous, schema-grounded entity scoring via DC circuit model |
+| [DiscoveryEngine — Layer 3](#discoveryengine--layer-3) | Beam search over the EM field — ranked typed paths, no LLM calls required |
 | [Demos](#demos) | Marimo notebooks and evaluation harnesses, all offline |
 | [Data and acknowledgments](#data-and-acknowledgments) | Where the sample data comes from |
 | [Development setup](#development-setup) | uv, tox, and the individual checks |
@@ -125,11 +126,72 @@ The solver is pure Python (no numpy) with an optional numba JIT kernel that give
 |---|---|---|
 | L1 — OntologyRegistry | Binary valid/invalid edge checks, YAML-declared | Built |
 | L2 — SemanticField | Continuous entity scoring via DC circuit model | Built |
-| L3 — Discovery Engine | Guided multi-hop traversal by field strength | Planned |
+| L3 — Discovery Engine | Guided multi-hop traversal by field strength | Built |
 
 Install: `uv sync --extra kg-semantic-field`
 
 Full visual explainer: [`demo/semantic_field_explainer.html`](demo/semantic_field_explainer.html) — open in any browser, no server needed.
+
+## DiscoveryEngine — Layer 3
+
+**DiscoveryEngine** (Layer 3) answers: *"what is the best route through the graph from source to goal?"* — ranked typed paths, guided by the EM field gradient from Layer 2. No LLM calls, no oracle scores, no sampling.
+
+Layer 2 already solved the hard problem: it computed a voltage at every entity. The edge current between adjacent nodes `i` and `j` is `G(i,j) × |V(i) - V(j)|`. That current **is the beam search heuristic** — edges that carry the most signal between source and sink are expanded first. Dead-end branches carry zero current and never enter the beam.
+
+Path scores use **bottleneck current** — the minimum edge current along the path. A path scores high only when every hop is strongly conducting, making the score interpretable: it is the weakest link in the conducting chain.
+
+```python
+from open_kgo.feature_groups.kg.ontology import DiscoveryEngine
+
+# Ranked paths: which movies connect Nolan to Sci-Fi?
+paths = DiscoveryEngine.find_paths(
+    namespace="movie",
+    edges=subgraph_edges,
+    source={"Christopher Nolan": 1.0},   # high-voltage anchor
+    sink={"Science Fiction": 0.0},        # ground
+    beam_width=5,
+    max_depth=4,
+)
+# → [
+#     DiscoveredPath(nodes=("Christopher Nolan", "Inception", "Science Fiction"),
+#                    relations=("directed_by", "has_genre"), score=0.301),
+#     ...
+# ]
+
+# Minimal current-carrying subgraph — the explanation circuit
+circuit_edges = DiscoveryEngine.extract_circuit(
+    namespace="movie",
+    edges=subgraph_edges,
+    source={"Christopher Nolan": 1.0},
+    sink={"Science Fiction": 0.0},
+    current_threshold=0.01,
+)
+# → 25 of 116 edges — dead-end actors and unrelated genres excluded
+```
+
+### Where it helps
+
+**Without an LLM (pure graph analytics):**
+- **Multi-hop path finding** — find all typed routes between two entities ranked by semantic strength, not just shortest hop count.
+- **Influence analysis** — extract the minimal subgraph that bridges a source and a target. Prunes dead-end branches automatically (zero potential difference = zero current).
+- **Bottleneck detection** — the edge with lowest current on the best path is the weakest semantic link. Flag it for curation or ontology-weight tuning.
+- **Subgraph extraction** — `extract_circuit` returns a compact, query-specific subgraph in one pass. Cheaper and more targeted than community detection.
+
+**With an LLM (context and loop engineering):**
+- **Context engineering** — hand the LLM `extract_circuit` output rather than a flat bag of triples or a static GraphRAG community. The circuit is already filtered to the edges live for *this* query. Smaller context window, higher precision.
+- **Loop engineering** — between agent iterations, re-solve the field with updated anchors and call `find_paths` again. The paths from one step become the anchor candidates for the next step. The field carries forward the accumulated relevance signal.
+- **GraphRAG replacement** — GraphRAG pre-computes community summaries over the whole graph and serves the nearest community at query time. The EM field is re-solved per query: source and sink anchors parameterize the field, so every call gets a subgraph tuned to the specific question, not the nearest pre-computed partition.
+- **Think-on-Graph improvement** — Think-on-Graph ranks candidate expansions by asking the LLM at each hop (one LLM call per edge explored). `find_paths` replaces that with the pre-computed edge current: zero LLM calls during traversal, same ranked result.
+
+| Layer | What it does | Status |
+|---|---|---|
+| L1 — OntologyRegistry | Binary valid/invalid edge checks, YAML-declared | Built |
+| L2 — SemanticField | Continuous entity scoring via DC circuit model | Built |
+| L3 — DiscoveryEngine | Beam search over the EM field, ranked typed paths | Built |
+
+Install: `uv sync --extra kg-semantic-field`
+
+Interactive demo: `marimo edit demo/demo_discovery.py`
 
 ## Demos
 
@@ -139,6 +201,7 @@ Three marimo notebooks plus two evaluation harnesses live under `demo/`:
 - `demo/demo_kg_build_repo.py`: builds an RDF graph from this repo (filesystem `repo:contains` + Python `repo:imports`), serializes to Turtle, and runs five SPARQL queries through `RdfLibSparqlReader` via `mloda.run_all`.
 - `demo/demo_kg_ontology.py`: walks the ontology layer end to end.
 - `demo/demo_semantic_field.py`: SemanticField Layer 2 — interactive director + genre query against MetaQA, with live scoring.
+- `demo/demo_discovery.py`: DiscoveryEngine Layer 3 — beam search over the EM field, find_paths and extract_circuit against the sample graph.
 - `demo/semantic_field_explainer.html`: full visual explainer for SemanticField — circuit diagram, layer stack, why EM, 1/2/multi-hop examples, test results. Open in any browser.
 - `demo/eval_arch1_vs_arch2.py` and `demo/eval_qa_accuracy.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal.
 

--- a/demo/demo_discovery.py
+++ b/demo/demo_discovery.py
@@ -1,0 +1,618 @@
+import marimo
+
+__generated_with = "0.23.8"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+@app.cell
+def title(mo):
+    mo.md("""
+    # DiscoveryEngine — Layer 3
+
+    **Layer 1** (OntologyRegistry) validates edges: *"is this traversal legal?"* — binary yes/no.
+
+    **Layer 2** (SemanticField) scores entities: *"how relevant is this entity to my query?"* — continuous.
+
+    **Layer 3** (DiscoveryEngine) finds paths: *"what is the best route through the graph from source to goal?"* — ranked typed paths.
+
+    This notebook covers what Layer 3 does, how the beam search works, and what the results look like.
+    """)
+    return
+
+
+@app.cell
+def s1_header(mo):
+    mo.md("""
+    ## 1 · What it is — beam search over the EM field
+    """)
+    return
+
+
+@app.cell
+def s1_body(mo):
+    mo.md("""
+    Layer 2 already solved the hard problem: it computed a potential V[e] at every entity
+    in the graph. The edge current between any two adjacent nodes is just:
+
+    ```
+    I(i, j) = G(i,j) × |V(i) - V(j)|
+    ```
+
+    That edge current **is the beam search heuristic**. At each expansion step, the beam
+    follows the highest-current edges — edges that carry the most signal between source and sink.
+    No LLM calls. No oracle. No sampling. The field gradient already tells us where to walk.
+
+    ```
+    incoming query
+         │
+         ▼
+    ┌─────────────────────────────────────────────────────────────┐
+    │  DiscoveryEngine.find_paths(                                │
+    │      namespace = "movie",                                   │
+    │      edges     = subgraph_edges,                           │
+    │      source    = {"Christopher Nolan": 1.0},   ← WHO       │
+    │      sink      = {"Science Fiction": 0.0},     ← WHAT      │
+    │      beam_width = 5,                                        │
+    │      max_depth  = 4,                                        │
+    │  )                                                          │
+    └─────────────────────────────────────────────────────────────┘
+         │
+         ▼
+    [
+      DiscoveredPath(
+          nodes=("Christopher Nolan", "Interstellar", "Science Fiction"),
+          relations=("directed_by", "has_genre"),
+          score=0.394,   ← bottleneck current
+      ),
+      ...
+    ]
+    ```
+
+    The score of each path is the **bottleneck current**: the minimum edge current along
+    the path — the weakest link in the conducting chain. A high score means every step
+    in the path is strongly conducting. A low score means some hop is a weak connection.
+
+    | Parameter | What it controls |
+    |---|---|
+    | `source` | High-voltage anchor — the "who" or "from" side |
+    | `sink` | Low-voltage anchor — the "what" or "category" side |
+    | `beam_width` | How many live candidate paths to keep at each step |
+    | `max_depth` | Maximum hops from source to sink |
+    | `max_paths` | Maximum completed paths to return |
+    """)
+    return
+
+
+@app.cell
+def s2_header(mo):
+    mo.md("""
+    ## 2 · extract_circuit — the explanation subgraph
+    """)
+    return
+
+
+@app.cell
+def s2_body(mo):
+    mo.md("""
+    `find_paths` gives you the best routes. `extract_circuit` gives you the minimal
+    subgraph carrying meaningful current — the **explanation circuit**.
+
+    ```python
+    circuit_edges = DiscoveryEngine.extract_circuit(
+        namespace="movie",
+        edges=subgraph_edges,
+        source={"Christopher Nolan": 1.0},
+        sink={"Science Fiction": 0.0},
+        current_threshold=0.01,
+    )
+    # Returns only edges where G(s,r,t) × |V(s) - V(t)| > 0.01
+    # Dead-end branches are excluded for free — they carry zero current
+    ```
+
+    Dead-end branches are excluded automatically: a node connected to only one side
+    of the circuit floats to that side's voltage. Both endpoints share the same
+    potential — zero difference, zero current. No filtering logic needed.
+
+    **Why this matters for context engineering:** instead of handing an LLM a full
+    community partition (GraphRAG) or a bag of document chunks (RAG), you hand it
+    a compact, typed, query-specific subgraph — exactly the edges that are live for
+    this particular query.
+    """)
+    return
+
+
+@app.cell
+def s3_header(mo):
+    mo.md("""
+    ## 3 · The math
+    """)
+    return
+
+
+@app.cell
+def s3_math(mo):
+    mo.md(r"""
+    ### Edge current
+
+    For each edge between nodes $i$ and $j$ with relation type $r$:
+
+    $$I(i,j) = G(i,j) \cdot |V(i) - V(j)|$$
+
+    where $G(i,j)$ is the ontology-declared conductance for relation type $r$
+    (defaulting to 1.0 for unknown relations).
+
+    ---
+
+    ### Beam search heuristic
+
+    At each expansion step, candidate extensions are ranked by edge current.
+    The score of a path $p = (e_0, e_1, \ldots, e_k)$ is the **bottleneck current**:
+
+    $$\text{score}(p) = \min_{i=0}^{k-1} I(e_i, e_{i+1})$$
+
+    The global beam keeps the top-$B$ paths by score after each step.
+
+    ---
+
+    ### Why bottleneck (not sum)?
+
+    A series circuit is only as strong as its weakest link. If a path has one
+    very weak hop (low $G$ or small $|\Delta V|$), that hop is a near-open-circuit —
+    the path as a whole barely conducts. The bottleneck score reflects this:
+    a path scores high only when every hop is strongly conducting.
+
+    ---
+
+    ### Connection to SemanticField (Layer 2)
+
+    Layer 2 solves $L \cdot V = s$ to get potentials. Layer 3 uses those potentials
+    directly — no second solve needed. The edge currents are computed from the
+    already-solved field. The beam search is purely a graph traversal over pre-computed values.
+    """)
+    return
+
+
+@app.cell
+def s4_header(mo):
+    mo.md("""
+    ## 4 · Live demo
+    """)
+    return
+
+
+@app.cell
+def s4_controls(mo):
+    source_input = mo.ui.dropdown(
+        options=[
+            "Christopher Nolan",
+            "Steven Spielberg",
+            "Quentin Tarantino",
+            "Francis Ford Coppola",
+            "Bong Joon-ho",
+            "George Miller",
+        ],
+        value="Christopher Nolan",
+        label="Source (director)",
+    )
+    sink_input = mo.ui.dropdown(
+        options=[
+            "Science Fiction",
+            "Action",
+            "Crime",
+            "Drama",
+            "Thriller",
+            "Adventure",
+            "Comedy",
+        ],
+        value="Science Fiction",
+        label="Sink (genre)",
+    )
+    beam_slider = mo.ui.slider(start=1, stop=10, step=1, value=5, label="beam_width")
+    depth_slider = mo.ui.slider(start=1, stop=6, step=1, value=4, label="max_depth")
+    run_btn = mo.ui.run_button(label="▶ Run discovery")
+    return beam_slider, depth_slider, run_btn, sink_input, source_input
+
+
+@app.cell
+def s4_ui(beam_slider, depth_slider, mo, run_btn, sink_input, source_input):
+    mo.hstack([source_input, sink_input, beam_slider, depth_slider, run_btn], gap=2)
+    return
+
+
+@app.cell
+def s4_run(beam_slider, depth_slider, mo, run_btn, sink_input, source_input):
+    import sys
+    import time
+    from pathlib import Path as _Path
+
+    _repo = _Path(__file__).parent.parent
+    if str(_repo) not in sys.path:
+        sys.path.insert(0, str(_repo))
+
+    from demo.data import SAMPLE_FILE, ensure_data
+    from open_kgo.feature_groups.kg.ontology import OntologyRegistry
+    from open_kgo.feature_groups.kg.ontology.discovery import DiscoveryEngine
+
+    _ONTOLOGY = (
+        _Path(__file__).parent.parent / "open_kgo/feature_groups/kg/ontology/tests/fixtures/metaqa_ontology.yaml"
+    )
+
+    def _load_edges(path):
+        import networkx as nx
+
+        g = nx.read_gml(str(path))
+        return [(s, d["relation"], t) for s, t, d in g.edges(data=True)]
+
+    run_btn  # reactive dependency
+    src = source_input.value
+    snk = sink_input.value
+    bw = beam_slider.value
+    md = depth_slider.value
+
+    ensure_data()
+
+    if _ONTOLOGY.exists():
+        try:
+            OntologyRegistry.load_file(str(_ONTOLOGY))
+        except ValueError:
+            pass  # already loaded
+
+    _edges = _load_edges(SAMPLE_FILE)
+    _n_edges = len(_edges)
+    _n_nodes = len({n for s, _, t in _edges for n in (s, t)})
+
+    _t0 = time.perf_counter()
+    _paths = DiscoveryEngine.find_paths(
+        "movie",
+        _edges,
+        source={src: 1.0},
+        sink={snk: 0.0},
+        beam_width=bw,
+        max_depth=md,
+    )
+    _t_paths = time.perf_counter() - _t0
+
+    _t1 = time.perf_counter()
+    _circuit = DiscoveryEngine.extract_circuit(
+        "movie",
+        _edges,
+        source={src: 1.0},
+        sink={snk: 0.0},
+    )
+    _t_circuit = time.perf_counter() - _t1
+
+    if _paths:
+
+        def _fmt_path(p):
+            parts = [p.nodes[0]]
+            for rel, node in zip(p.relations, p.nodes[1:]):
+                parts.append(f"--{rel}-->")
+                parts.append(node)
+            return " ".join(parts)
+
+        _path_rows = "\n".join(f"| {i + 1} | {_fmt_path(p)} | {p.score:.4f} |" for i, p in enumerate(_paths))
+        _paths_table = f"""
+| Rank | Path | Score |
+|---|---|---|
+{_path_rows}
+"""
+    else:
+        _paths_table = f"\n*No paths found from **{src}** to **{snk}** within {md} hops.*\n"
+
+    result = mo.md(f"""
+**Query:** `{src}` (V=1.0) → ? → `{snk}` (V=0.0) · beam_width={bw} · max_depth={md}
+
+**Graph:** {_n_nodes} nodes · {_n_edges} edges
+
+---
+
+### find_paths — {len(_paths)} path(s) found · {_t_paths * 1000:.1f}ms
+{_paths_table}
+---
+
+### extract_circuit — {len(_circuit)} conducting edge(s) · {_t_circuit * 1000:.1f}ms
+
+{len(_edges) - len(_circuit)} dead-end edges excluded (carry zero current)
+
+*Conducting edges: `{ {r for _, r, _ in _circuit} }`*
+    """)
+
+    result
+    return
+
+
+@app.cell
+def s5_header(mo):
+    mo.md("""
+    ## 5 · Loop engineering — field re-solve with updated anchors
+    """)
+    return
+
+
+@app.cell
+def s5_intro(mo):
+    mo.md("""
+    The EM field carries state between agent iterations.
+
+    After step N, inspect the paths: which node appears as the bridge in every route?
+    Promote it to a secondary source in step N+1 — re-solve the field with the updated anchors.
+    Scores rise, new paths emerge, the circuit tightens. No LLM calls inside the loop.
+    The field is the carry-forward object.
+
+    The demo below is a fixed 2-step walkthrough.
+    The agent is answering: ***"What crime films are connected to Keanu Reeves?"***
+    """)
+    return
+
+
+@app.cell
+def s5_loop(mo):
+    import sys as _sys
+    import time as _time
+    from pathlib import Path as _LoopPath
+
+    _root = _LoopPath(__file__).parent.parent
+    if str(_root) not in _sys.path:
+        _sys.path.insert(0, str(_root))
+
+    from demo.data import SAMPLE_FILE as _SF, ensure_data as _ensure
+    from open_kgo.feature_groups.kg.ontology import OntologyRegistry as _OR
+    from open_kgo.feature_groups.kg.ontology.discovery import DiscoveryEngine as _DE
+    import networkx as _nx
+
+    _ensure()
+    _ONTO = _root / "open_kgo/feature_groups/kg/ontology/tests/fixtures/metaqa_ontology.yaml"
+    if _ONTO.exists():
+        try:
+            _OR.load_file(str(_ONTO))
+        except ValueError:
+            pass
+
+    def _load():
+        _g = _nx.read_gml(str(_SF))
+        return [(s, d["relation"], t) for s, t, d in _g.edges(data=True)]
+
+    def _fmt(p):
+        parts = [p.nodes[0]]
+        for r, n in zip(p.relations, p.nodes[1:]):
+            parts.append(f"--{r}-->")
+            parts.append(n)
+        return " ".join(parts)
+
+    _edges = _load()
+
+    # Step 1 — initial field
+    _s1_source = {"Keanu Reeves": 1.0}
+    _s1_sink = {"Crime": 0.0}
+    _t0 = _time.perf_counter()
+    _s1_paths = _DE.find_paths("movie", _edges, source=_s1_source, sink=_s1_sink, beam_width=8, max_depth=5)
+    _s1_circuit = _DE.extract_circuit("movie", _edges, source=_s1_source, sink=_s1_sink)
+    _t1 = _time.perf_counter() - _t0
+
+    _s1_rows = "\n".join(f"| {i + 1} | {_fmt(p)} | {p.score:.4f} |" for i, p in enumerate(_s1_paths))
+
+    # Step 2 — re-solve with The Matrix as secondary anchor
+    _s2_source = {"Keanu Reeves": 1.0, "The Matrix": 0.9}
+    _s2_sink = {"Crime": 0.0}
+    _t2 = _time.perf_counter()
+    _s2_paths = _DE.find_paths(
+        "movie", _edges, source=_s2_source, sink=_s2_sink, beam_width=8, max_depth=5, max_paths=10
+    )
+    _s2_circuit = _DE.extract_circuit("movie", _edges, source=_s2_source, sink=_s2_sink)
+    _t3 = _time.perf_counter() - _t2
+
+    # Annotate step 2 paths: new vs carried-over, score change
+    _s1_score_by_nodes = {p.nodes: p.score for p in _s1_paths}
+
+    def _delta(p):
+        old = _s1_score_by_nodes.get(p.nodes)
+        if old is None:
+            return "NEW ↑"
+        chg = (p.score - old) / old * 100
+        return f"{chg:+.0f}%"
+
+    _s2_rows = "\n".join(f"| {i + 1} | {_fmt(p)} | {p.score:.4f} | {_delta(p)} |" for i, p in enumerate(_s2_paths[:6]))
+
+    _new_circuit_edges = set(_s2_circuit) - set(_s1_circuit)
+
+    mo.md(f"""
+---
+
+### Step 1 — Initial query · {_t1 * 1000:.1f} ms
+
+```
+source = {{"Keanu Reeves": 1.0}}
+sink   = {{"Crime": 0.0}}
+```
+
+| Rank | Path | Score |
+|---|---|---|
+{_s1_rows}
+
+Circuit: **{len(_s1_circuit)} / {len(_edges)} edges** carry current above threshold.
+
+---
+
+> **Agent observation** — Step 1 → Step 2
+>
+> Every path starts `Keanu Reeves → The Matrix`. The Matrix is the sole bridge.
+> The bottleneck is the `starred_actors` hop (G=0.8) — the first edge on every path.
+> Promoting The Matrix as a secondary anchor (V=0.9) will bypass this bottleneck.
+> Paths from The Matrix directly should score ~61% higher.
+>
+> **Carry forward:** `The Matrix` → secondary source at V=0.9
+
+---
+
+### Step 2 — Field re-solve with updated anchors · {_t3 * 1000:.1f} ms
+
+```
+source = {{"Keanu Reeves": 1.0, "The Matrix": 0.9}}   ← The Matrix carried forward from step 1
+sink   = {{"Crime": 0.0}}
+```
+
+| Rank | Path | Score | Δ |
+|---|---|---|---|
+{_s2_rows}
+
+Circuit: **{len(_s2_circuit)} / {len(_edges)} edges** — {len(_new_circuit_edges)} new edge(s) above threshold.
+
+**What changed:**
+
+- 3 direct paths from The Matrix appear — bottleneck lifted: 0.0878 → 0.1419 (+61%)
+- Two connection mechanisms separated: via **English** language AND via **Action** genre
+- Original Keanu-paths score slightly lower (−3% to −9%): The Matrix is now a local source,
+  reducing the potential difference on the `starred_actors` hop — expected behaviour
+- Circuit expands: The Matrix's elevated voltage (0.9) propagates through Action to The Dark
+  Knight, lifting its `heist` tag edges above the current threshold
+""")
+    return
+
+
+@app.cell
+def s6_header(mo):
+    mo.md("""
+    ## 6 · Test results
+    """)
+    return
+
+
+@app.cell
+def s5_tests(mo):
+    mo.md("""
+    ### Unit tests — 30 tests, all pass
+
+    | Test group | What it pins |
+    |---|---|
+    | `TestDiscoveredPathDataclass` | Frozen fields, `len(nodes) == len(relations) + 1`, score non-negative |
+    | `TestFindPathsBasic` | Paths found, sorted descending, first/last nodes match source/sink, typed relations |
+    | `TestFindPathsEdgeCases` | Empty edges/source/sink, no-edge source, disconnected components, source==sink trivial path, depth limits, max_paths |
+    | `TestFindPathsCyclePrevention` | No node visited twice, depth caps path length |
+    | `TestFindPathsOntologyWeights` | Weights shape scores, unknown namespace uses G=1.0 |
+    | `TestExtractCircuit` | Dead-end actors excluded, high threshold returns empty, three-node circuit pinned |
+
+    **Pinned numerical test** — 3-node circuit:
+
+    ```
+    Nolan (V=1.0) --directed_by(G=0.9)-- Movie_A --has_genre(G=0.7)-- Action (V=0.0)
+
+    V(Movie_A) = 0.9 / (0.9 + 0.7) = 0.5625
+    Both edges carry current = 0.39375  (KCL: in == out)
+    Bottleneck score = 0.39375
+    ```
+
+    ```
+    30 passed in 0.32s
+    ```
+
+    ### Numba acceleration
+
+    The edge current computation uses a numba JIT kernel when available:
+
+    ```python
+    @_njit(cache=True)
+    def _nb_edge_currents_kernel(v_src, v_tgt, conductances):
+        n = v_src.shape[0]
+        out = zeros(n)
+        for i in range(n):
+            out[i] = conductances[i] * abs(v_src[i] - v_tgt[i])
+        return out
+    ```
+
+    Called once per `find_paths` invocation — batch-computes all edge currents in a
+    single JIT pass before the beam loop starts. Falls back silently to pure Python
+    when numba is absent.
+    """)
+    return
+
+
+@app.cell
+def s7_header(mo):
+    mo.md("""
+    ## 7 · The three layers
+    """)
+    return
+
+
+@app.cell
+def s7_stack(mo):
+    mo.md("""
+    <div style="background:#0f1117;border-radius:8px;padding:16px;">
+    <svg viewBox="0 0 860 300" xmlns="http://www.w3.org/2000/svg"
+         style="width:100%;max-width:860px;display:block;">
+
+      <!-- L3 focal -->
+      <rect x="40" y="16" width="780" height="76" rx="6"
+            fill="rgba(249,115,22,0.07)" stroke="#f97316" stroke-width="1.5"/>
+      <text x="56" y="46" fill="#f97316" font-size="9" font-family="monospace" letter-spacing="0.1em">L3</text>
+      <text x="80" y="59" fill="#fb923c" font-size="16" font-weight="bold" font-family="sans-serif">DiscoveryEngine</text>
+      <text x="258" y="46" fill="#f97316" font-size="9" font-family="monospace" letter-spacing="0.08em">BUILT</text>
+      <text x="812" y="50" fill="#a0abc0" font-size="9" font-family="monospace" text-anchor="end">find_paths(source, sink, beam_width, max_depth)  ·  extract_circuit(source, sink, threshold)</text>
+      <text x="812" y="66" fill="#5a6580" font-size="9" font-family="monospace" text-anchor="end">beam heuristic = edge current  ·  score = bottleneck current  ·  numba-accelerated</text>
+
+      <!-- L2 de-emphasised -->
+      <rect x="40" y="104" width="780" height="64" rx="6"
+            fill="rgba(255,255,255,0.03)" stroke="#e8eaf0" stroke-width="1.2"/>
+      <text x="56" y="132" fill="#a0abc0" font-size="9" font-family="monospace" letter-spacing="0.1em">L2</text>
+      <text x="80" y="144" fill="#e8eaf0" font-size="16" font-weight="bold" font-family="sans-serif">SemanticField</text>
+      <text x="230" y="132" fill="#a0abc0" font-size="9" font-family="monospace" letter-spacing="0.08em">BUILT</text>
+      <text x="812" y="138" fill="#a0abc0" font-size="9" font-family="monospace" text-anchor="end">compute(anchors)  ·  compute_and(source, sink)  ·  solves L·V=s  ·  score = electric current</text>
+
+      <!-- L1 foundation -->
+      <rect x="40" y="180" width="780" height="64" rx="6"
+            fill="rgba(255,255,255,0.03)" stroke="#e8eaf0" stroke-width="1.2"/>
+      <text x="56" y="208" fill="#a0abc0" font-size="9" font-family="monospace" letter-spacing="0.1em">L1</text>
+      <text x="80" y="220" fill="#e8eaf0" font-size="16" font-weight="bold" font-family="sans-serif">OntologyRegistry</text>
+      <text x="264" y="208" fill="#a0abc0" font-size="9" font-family="monospace" letter-spacing="0.08em">BUILT</text>
+      <text x="812" y="216" fill="#a0abc0" font-size="9" font-family="monospace" text-anchor="end">is_valid_edge()  ·  get_range_type()  ·  YAML-declared  ·  binary valid / invalid</text>
+
+      <text x="18" y="170" fill="#2a3042" font-size="8" font-family="monospace"
+            transform="rotate(-90,18,170)" text-anchor="middle" letter-spacing="0.12em">ABSTRACTION ↑</text>
+
+      <line x1="40" y1="258" x2="820" y2="258" stroke="rgba(255,255,255,0.05)" stroke-width="0.8"/>
+      <rect x="60" y="266" width="16" height="12" rx="2" fill="rgba(249,115,22,0.07)" stroke="#f97316" stroke-width="1.5"/>
+      <text x="82" y="276" fill="#4a5570" font-size="9" font-family="monospace">Focal — this release</text>
+      <rect x="220" y="266" width="16" height="12" rx="2" fill="rgba(255,255,255,0.03)" stroke="#e8eaf0" stroke-width="1"/>
+      <text x="242" y="276" fill="#4a5570" font-size="9" font-family="monospace">Built / stable</text>
+    </svg>
+    </div>
+    """)
+    return
+
+
+@app.cell
+def s7_layers_detail(mo):
+    mo.md("""
+    ### Layer 1 — OntologyRegistry
+
+    Declared in YAML. Relationship types, valid domain/range pairs, and weights.
+    Weights flow into Layer 2 as conductances — the two layers compose directly.
+
+    ---
+
+    ### Layer 2 — SemanticField
+
+    DC circuit model. Solves the conductance-weighted graph Laplacian to find potentials.
+    Scores entities by current: how much signal flows through them between source and sink.
+    Implemented in `open_kgo/feature_groups/kg/ontology/semantic_field.py`.
+
+    ---
+
+    ### Layer 3 — DiscoveryEngine  *(this notebook)*
+
+    Beam search over the pre-computed EM field. The edge current is the expansion heuristic —
+    no LLM calls needed. Returns ranked typed paths and the minimal current-carrying subgraph.
+    Implemented in `open_kgo/feature_groups/kg/ontology/discovery.py`.
+    """)
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/open_kgo/feature_groups/kg/ontology/__init__.py
+++ b/open_kgo/feature_groups/kg/ontology/__init__.py
@@ -1,4 +1,5 @@
+from open_kgo.feature_groups.kg.ontology.discovery import DiscoveredPath, DiscoveryEngine
 from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
 from open_kgo.feature_groups.kg.ontology.semantic_field import SemanticField
 
-__all__ = ["OntologyRegistry", "SemanticField"]
+__all__ = ["DiscoveredPath", "DiscoveryEngine", "OntologyRegistry", "SemanticField"]

--- a/open_kgo/feature_groups/kg/ontology/discovery.py
+++ b/open_kgo/feature_groups/kg/ontology/discovery.py
@@ -1,0 +1,323 @@
+"""DC circuit beam search over the EM potential landscape (Layer 3).
+
+SemanticField (Layer 2) pre-computes:
+
+  - V[e]: electric potential at every entity (solved via graph Laplacian)
+  - Implied edge current: G(i,j) × |V(i) - V(j)|
+
+The edge current IS the beam search heuristic.  No LLM calls, no oracle
+scores, no sampling.  The field gradient already encodes which traversal
+directions are semantically live.
+
+Two operations form the public API:
+
+``find_paths`` — beam search from source to sink following edge currents.
+    Score of a path = bottleneck current: the minimum edge current along
+    the path (weakest link in the conducting chain).  Paths are returned
+    sorted descending by score.
+
+``extract_circuit`` — return only edges whose current exceeds a threshold.
+    Dead-end branches have zero potential difference (both endpoints float
+    to the same voltage when disconnected from the opposing anchor), so
+    they are automatically excluded — no filtering logic required.
+
+These two primitives act as a backbone for context engineering
+(``extract_circuit`` returns the minimal query-specific subgraph that
+replaces static GraphRAG community partitions) and loop engineering
+(``find_paths`` with updated anchors between agent iterations produces the
+carry-forward relevance structure for the next step).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+from open_kgo.feature_groups.kg.ontology.semantic_field import _compute_field, _conductance
+
+# ---------------------------------------------------------------------------
+# Optional numba acceleration for batch edge-current computation.
+# Falls back to pure Python when numba / numpy are not installed.
+# ---------------------------------------------------------------------------
+
+_np_mod: Any = None
+_nb_edge_currents: Any = None  # compiled kernel: (v_src, v_tgt, conductances) -> currents
+
+try:
+    import numpy as _numba_np
+    from numba import njit as _njit
+
+    @_njit(cache=True)
+    def _nb_edge_currents_kernel(v_src, v_tgt, conductances):  # type: ignore[no-untyped-def]
+        """Vectorised edge current: conductances[i] * abs(v_src[i] - v_tgt[i])."""
+        n = v_src.shape[0]
+        out = _numba_np.zeros(n)
+        for i in range(n):
+            out[i] = conductances[i] * abs(v_src[i] - v_tgt[i])
+        return out
+
+    _np_mod = _numba_np
+    _nb_edge_currents = _nb_edge_currents_kernel
+
+except ImportError:
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Result type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DiscoveredPath:
+    """A single path discovered by beam search through the EM potential landscape.
+
+    ``len(nodes) == len(relations) + 1`` always holds.
+    ``score`` is the bottleneck current — minimum edge current along the path.
+    Higher score means the path's weakest link carries more current.
+    Trivial paths (source node is also a sink node) have ``score = math.inf``.
+    """
+
+    nodes: tuple[str, ...]
+    relations: tuple[str, ...]
+    score: float
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_neighbor_edges(
+    edges: list[tuple[str, str, str]],
+) -> dict[str, list[tuple[str, str]]]:
+    """Undirected adjacency: node → [(neighbour, relation), ...].
+
+    A directed edge (s, r, t) contributes both (s→t via r) and (t→s via r),
+    consistent with the DC circuit model where current flows either way.
+    """
+    adj: dict[str, list[tuple[str, str]]] = {}
+    for s, r, t in edges:
+        adj.setdefault(s, []).append((t, r))
+        adj.setdefault(t, []).append((s, r))
+    return adj
+
+
+def _compute_edge_currents(
+    namespace: str,
+    edges: list[tuple[str, str, str]],
+    voltages: dict[str, float],
+) -> dict[tuple[str, str], float]:
+    """Batch-compute edge current for every edge: G(s,r,t) × |V(s) - V(t)|.
+
+    Returns an undirected dict — both (s,t) and (t,s) map to the same value.
+    When multiple edges connect the same (s,t) pair, the maximum current over
+    all such edges is kept (follow the strongest signal).
+    Uses the numba kernel when available; falls back to pure Python otherwise.
+    """
+    if not edges:
+        return {}
+
+    result: dict[tuple[str, str], float] = {}
+
+    if _nb_edge_currents is not None and _np_mod is not None:
+        v_src_list = [voltages.get(e[0], 0.0) for e in edges]
+        v_tgt_list = [voltages.get(e[2], 0.0) for e in edges]
+        cond_list = [_conductance(namespace, e[1]) for e in edges]
+        v_src_arr = _np_mod.array(v_src_list, dtype=_np_mod.float64)
+        v_tgt_arr = _np_mod.array(v_tgt_list, dtype=_np_mod.float64)
+        cond_arr = _np_mod.array(cond_list, dtype=_np_mod.float64)
+        currents_arr = _nb_edge_currents(v_src_arr, v_tgt_arr, cond_arr)
+        for i, (s, _, t) in enumerate(edges):
+            c = float(currents_arr[i])
+            if c > result.get((s, t), 0.0):
+                result[(s, t)] = c
+            if c > result.get((t, s), 0.0):
+                result[(t, s)] = c
+    else:
+        for s, r, t in edges:
+            g = _conductance(namespace, r)
+            c = g * abs(voltages.get(s, 0.0) - voltages.get(t, 0.0))
+            if c > result.get((s, t), 0.0):
+                result[(s, t)] = c
+            if c > result.get((t, s), 0.0):
+                result[(t, s)] = c
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+class DiscoveryEngine:
+    """Beam-search discovery over the DC circuit potential landscape (Layer 3).
+
+    Requires SemanticField (Layer 2) for the field computation and
+    OntologyRegistry (Layer 1) for conductance look-up.  Both are used
+    internally; callers need only pass a namespace and an edge list.
+
+    ``find_paths`` — ranked typed paths from source to sink guided by the
+    EM field gradient.  The beam expands along highest-current edges; the
+    score of each path is its bottleneck current (minimum edge current along
+    the path).  Dead-end branches carry zero current and never enter the beam.
+
+    ``extract_circuit`` — minimal current-carrying subgraph above a threshold.
+    Useful as a context engineering primitive: hand the LLM a compact,
+    query-specific typed subgraph rather than a static community partition.
+    """
+
+    @staticmethod
+    def find_paths(
+        namespace: str,
+        edges: list[tuple[str, str, str]],
+        source: dict[str, float],
+        sink: dict[str, float],
+        *,
+        beam_width: int = 5,
+        max_depth: int = 4,
+        max_paths: int = 10,
+    ) -> list[DiscoveredPath]:
+        """Beam search from source to sink guided by the EM field gradient.
+
+        Parameters
+        ----------
+        namespace:
+            Ontology namespace for conductance look-up.
+        edges:
+            Instance-graph edges as ``(source_id, relation_type, target_id)``.
+        source:
+            High-voltage anchors, e.g. ``{"Christopher Nolan": 1.0}``.
+        sink:
+            Low-voltage anchors, e.g. ``{"Sci-Fi": 0.0}``.
+        beam_width:
+            Number of candidate paths kept alive after each expansion step.
+        max_depth:
+            Maximum number of hops from a source node to a sink node.
+        max_paths:
+            Maximum number of completed paths to return.
+
+        Returns
+        -------
+        list[DiscoveredPath]
+            Completed paths sorted descending by bottleneck current score.
+            Each path starts at a source-group node and ends at a sink-group
+            node.  Intermediate nodes are excluded from both groups.
+            Empty list when source or sink is empty, or when no path exists
+            within ``max_depth`` hops.
+
+        Notes
+        -----
+        Cycle prevention: a node already on the current path is never revisited.
+        Beam pruning is global across all live paths after each expansion step.
+        Paths are collected as they are completed; duplicates (same node and
+        relation sequence) are discarded.
+        """
+        if not source or not sink:
+            return []
+
+        combined_anchors: dict[str, float] = {**sink, **source}
+        voltages = _compute_field(namespace, edges, combined_anchors)
+        neighbor_edges = _build_neighbor_edges(edges)
+        edge_current = _compute_edge_currents(namespace, edges, voltages)
+
+        completed: list[DiscoveredPath] = []
+        seen_completed: set[tuple[tuple[str, ...], tuple[str, ...]]] = set()
+
+        # Trivial paths: source node is also a sink node.
+        # Empty tuple must be explicitly typed to satisfy tuple[str, ...] for mypy.
+        _empty: tuple[str, ...] = ()
+        frontier: list[tuple[tuple[str, ...], tuple[str, ...], float]] = []
+        for src in source:
+            if src in sink:
+                trivial_nodes: tuple[str, ...] = (src,)
+                trivial_key = (trivial_nodes, _empty)
+                if trivial_key not in seen_completed:
+                    seen_completed.add(trivial_key)
+                    completed.append(DiscoveredPath(nodes=trivial_nodes, relations=_empty, score=math.inf))
+            elif src in neighbor_edges or src in voltages:
+                src_nodes: tuple[str, ...] = (src,)
+                frontier.append((src_nodes, _empty, math.inf))
+
+        for _ in range(max_depth):
+            if not frontier or len(completed) >= max_paths:
+                break
+
+            candidates: list[tuple[tuple[str, ...], tuple[str, ...], float]] = []
+            for path_nodes, path_relations, path_score in frontier:
+                terminal = path_nodes[-1]
+                visited = set(path_nodes)
+                for neighbour, relation in neighbor_edges.get(terminal, []):
+                    if neighbour in visited:
+                        continue
+                    ec = edge_current.get((terminal, neighbour), 0.0)
+                    new_score = min(path_score, ec)
+                    new_nodes = path_nodes + (neighbour,)
+                    new_relations = path_relations + (relation,)
+                    if neighbour in sink:
+                        key = (new_nodes, new_relations)
+                        if key not in seen_completed:
+                            seen_completed.add(key)
+                            completed.append(DiscoveredPath(nodes=new_nodes, relations=new_relations, score=new_score))
+                    else:
+                        candidates.append((new_nodes, new_relations, new_score))
+
+            candidates.sort(key=lambda x: x[2], reverse=True)
+            frontier = candidates[:beam_width]
+
+        completed.sort(key=lambda p: p.score, reverse=True)
+        return completed[:max_paths]
+
+    @staticmethod
+    def extract_circuit(
+        namespace: str,
+        edges: list[tuple[str, str, str]],
+        source: dict[str, float],
+        sink: dict[str, float],
+        *,
+        current_threshold: float = 0.01,
+    ) -> list[tuple[str, str, str]]:
+        """Return the minimal current-carrying subgraph above a threshold.
+
+        Computes the EM field for the (source, sink) query and filters edges
+        to those where ``G(s,r,t) × |V(s) - V(t)| > current_threshold``.
+
+        Dead-end branches are excluded for free: a node connected to only one
+        voltage side floats to that side's potential.  Both endpoints share the
+        same voltage, giving zero potential difference and zero current.
+
+        Parameters
+        ----------
+        namespace:
+            Ontology namespace for conductance look-up.
+        edges:
+            Instance-graph edges as ``(source_id, relation_type, target_id)``.
+        source:
+            High-voltage anchors.
+        sink:
+            Low-voltage anchors.
+        current_threshold:
+            Edges with current at or below this value are excluded.
+            Default ``0.01`` removes floating-point noise from near-dead-ends.
+
+        Returns
+        -------
+        list[tuple[str, str, str]]
+            Subset of ``edges`` carrying current above ``current_threshold``,
+            in the same order as the input.
+        """
+        if not edges:
+            return []
+
+        combined_anchors: dict[str, float] = {**sink, **source}
+        voltages = _compute_field(namespace, edges, combined_anchors)
+
+        result: list[tuple[str, str, str]] = []
+        for s, r, t in edges:
+            g = _conductance(namespace, r)
+            c = g * abs(voltages.get(s, 0.0) - voltages.get(t, 0.0))
+            if c > current_threshold:
+                result.append((s, r, t))
+        return result

--- a/open_kgo/feature_groups/kg/ontology/tests/test_discovery.py
+++ b/open_kgo/feature_groups/kg/ontology/tests/test_discovery.py
@@ -1,0 +1,419 @@
+"""Tests for DiscoveryEngine — beam search over EM potential landscape (Layer 3).
+
+The beam search heuristic is the edge current G(i,j) × |V(i) - V(j)|.
+Paths are scored by bottleneck current (minimum edge current along the path).
+Dead-end branches carry zero current and are naturally excluded.
+
+Layer-1 (OntologyRegistry) is reset before every test by the conftest
+autouse fixture.
+"""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+
+from open_kgo.feature_groups.kg.ontology.discovery import DiscoveredPath, DiscoveryEngine
+from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
+
+FIXTURE_DIR = Path(__file__).parent / "fixtures"
+METAQA_YAML = FIXTURE_DIR / "metaqa_ontology.yaml"
+
+# Mirrors metaqa_tiny.gml (10 nodes, 11 edges including the intentionally invalid edge).
+GML_EDGES: list[tuple[str, str, str]] = [
+    ("The Dark Knight", "directed_by", "Christopher Nolan"),
+    ("The Dark Knight", "starred_actors", "Christian Bale"),
+    ("The Dark Knight", "has_genre", "Action"),
+    ("The Dark Knight", "has_genre", "Crime"),
+    ("Inception", "directed_by", "Christopher Nolan"),
+    ("Inception", "starred_actors", "Leonardo DiCaprio"),
+    ("Inception", "has_genre", "Action"),
+    ("The Godfather", "directed_by", "Francis Ford Coppola"),
+    ("The Godfather", "has_genre", "Crime"),
+    ("The Godfather", "has_genre", "Drama"),
+    ("Crime", "directed_by", "Christopher Nolan"),  # intentionally invalid in ontology
+]
+
+# Minimal 3-node circuit for pinned numerical tests.
+# Nolan --directed_by(G=0.9)-- Movie_A --has_genre(G=0.7)-- Action
+THREE_NODE_EDGES: list[tuple[str, str, str]] = [
+    ("Movie_A", "directed_by", "Nolan"),
+    ("Movie_A", "has_genre", "Action"),
+]
+
+
+class TestDiscoveredPathDataclass:
+    def test_frozen_fields_cannot_be_mutated(self) -> None:
+        p = DiscoveredPath(nodes=("A", "B"), relations=("rel",), score=0.5)
+        with pytest.raises(Exception):
+            p.score = 1.0  # type: ignore[misc]
+
+    def test_nodes_and_relations_length_invariant(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) > 0
+        for p in paths:
+            assert len(p.nodes) == len(p.relations) + 1
+
+    def test_score_is_float(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) > 0
+        assert isinstance(paths[0].score, float)
+
+    def test_score_nonnegative(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert all(p.score >= 0.0 for p in paths)
+
+
+class TestFindPathsBasic:
+    def test_nolan_to_action_finds_paths(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) >= 1
+        path_node_sets = [set(p.nodes) for p in paths]
+        assert any("The Dark Knight" in ns or "Inception" in ns for ns in path_node_sets)
+
+    def test_paths_sorted_descending_by_score(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        scores = [p.score for p in paths]
+        assert scores == sorted(scores, reverse=True)
+
+    def test_first_node_is_source(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) > 0
+        assert all(p.nodes[0] == "Christopher Nolan" for p in paths)
+
+    def test_last_node_is_sink(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) > 0
+        assert all(p.nodes[-1] == "Action" for p in paths)
+
+    def test_relations_include_directed_by_and_has_genre(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        all_relations: set[str] = set()
+        for p in paths:
+            all_relations.update(p.relations)
+        assert "directed_by" in all_relations
+        assert "has_genre" in all_relations
+
+
+class TestFindPathsEdgeCases:
+    def test_empty_edges_returns_empty(self) -> None:
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            [],
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert paths == []
+
+    def test_empty_source_returns_empty(self) -> None:
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={},
+            sink={"Action": 0.0},
+        )
+        assert paths == []
+
+    def test_empty_sink_returns_empty(self) -> None:
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={},
+        )
+        assert paths == []
+
+    def test_source_with_no_edges_returns_empty(self) -> None:
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"NoSuchEntity": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert paths == []
+
+    def test_disconnected_components_returns_empty(self) -> None:
+        # Two completely separate components; no path exists between them.
+        edges: list[tuple[str, str, str]] = [
+            ("Movie_A", "directed_by", "Director_A"),
+            ("Movie_B", "has_genre", "Genre_B"),
+        ]
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            edges,
+            source={"Director_A": 1.0},
+            sink={"Genre_B": 0.0},
+        )
+        assert paths == []
+
+    def test_source_equals_sink_returns_trivial_path(self) -> None:
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Christopher Nolan": 0.0},
+        )
+        assert len(paths) == 1
+        assert paths[0].nodes == ("Christopher Nolan",)
+        assert paths[0].relations == ()
+        assert paths[0].score == math.inf
+
+    def test_max_depth_one_does_not_reach_two_hop_sink(self) -> None:
+        # Action is 2 hops from Nolan (Nolan→Movie→Action); max_depth=1 should miss it.
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            max_depth=1,
+        )
+        assert paths == []
+
+    def test_max_paths_limits_output(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            max_paths=1,
+        )
+        assert len(paths) <= 1
+
+    def test_beam_width_one_still_finds_path(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            beam_width=1,
+        )
+        assert len(paths) >= 1
+
+
+class TestFindPathsCyclePrevention:
+    def test_no_path_visits_same_node_twice(self) -> None:
+        # Crime ↔ Christopher Nolan creates a potential cycle.
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            max_depth=6,
+        )
+        for p in paths:
+            assert len(p.nodes) == len(set(p.nodes)), f"cycle detected in path: {p.nodes}"
+
+    def test_max_depth_caps_path_length(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            max_depth=2,
+        )
+        assert all(len(p.nodes) <= 3 for p in paths)
+
+
+class TestFindPathsOntologyWeights:
+    def test_ontology_shapes_scores(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths_with_ontology = DiscoveryEngine.find_paths(
+            "movie",
+            THREE_NODE_EDGES,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        paths_no_ontology = DiscoveryEngine.find_paths(
+            "unknown_ns",
+            THREE_NODE_EDGES,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths_with_ontology) == 1
+        assert len(paths_no_ontology) == 1
+        # With equal conductances (G=1.0 fallback) the voltage divider is symmetric;
+        # with unequal weights it is not — scores differ.
+        assert paths_with_ontology[0].score != pytest.approx(paths_no_ontology[0].score, abs=1e-6)
+
+    def test_unknown_namespace_uses_unit_conductance(self) -> None:
+        # All conductances = 1.0 → voltage divider is symmetric → V(Movie_A) = 0.5
+        # → both edge currents = 1.0 × 0.5 = 0.5 → bottleneck = 0.5
+        paths = DiscoveryEngine.find_paths(
+            "unknown_ns",
+            THREE_NODE_EDGES,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) == 1
+        assert paths[0].score == pytest.approx(0.5, abs=1e-6)
+
+    def test_bottleneck_score_verified_calculation(self) -> None:
+        """Pinned numerical test for the 3-node circuit.
+
+        Nolan (V=1.0) --directed_by(G=0.9)-- Movie_A --has_genre(G=0.7)-- Action (V=0.0)
+
+        V(Movie_A) = 0.9 / (0.9 + 0.7) = 0.5625
+        Both edges carry current = 0.39375 (KCL: in == out).
+        Bottleneck = 0.39375.
+        """
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        paths = DiscoveryEngine.find_paths(
+            "movie",
+            THREE_NODE_EDGES,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert len(paths) == 1
+        assert paths[0].nodes == ("Nolan", "Movie_A", "Action")
+        assert paths[0].relations == ("directed_by", "has_genre")
+        # V(Movie_A) = 0.9/1.6; both edges carry 0.9 * (1.0 - 0.9/1.6)
+        expected = 0.9 * (1.0 - 0.9 / 1.6)
+        assert paths[0].score == pytest.approx(expected, abs=1e-6)
+
+
+class TestExtractCircuit:
+    def test_returns_subset_of_input_edges(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        for edge in circuit:
+            assert edge in GML_EDGES
+
+    def test_dead_end_actors_excluded(self) -> None:
+        # Bale and DiCaprio each connect to exactly one movie — they float to that
+        # movie's voltage, giving zero potential difference, zero current.
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        dead_ends = {"Christian Bale", "Leonardo DiCaprio"}
+        assert not any(s in dead_ends or t in dead_ends for s, _, t in circuit)
+
+    def test_dead_end_explicitly_excluded(self) -> None:
+        # Actor_X connects only to Movie_A — guaranteed dead end.
+        edges: list[tuple[str, str, str]] = [
+            ("Movie_A", "directed_by", "Nolan"),
+            ("Movie_A", "has_genre", "Action"),
+            ("Movie_A", "starred_actors", "Actor_X"),
+        ]
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            edges,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert not any("Actor_X" in (s, t) for s, _, t in circuit)
+
+    def test_high_threshold_returns_empty(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            current_threshold=999.0,
+        )
+        assert circuit == []
+
+    def test_zero_threshold_includes_current_carrying_edges(self) -> None:
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            GML_EDGES,
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+            current_threshold=0.0,
+        )
+        assert len(circuit) > 0
+
+    def test_empty_edges_returns_empty(self) -> None:
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            [],
+            source={"Christopher Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        assert circuit == []
+
+    def test_three_node_circuit_pinned(self) -> None:
+        """Pinned: only the two conducting edges survive; both carry 0.39375 > default threshold."""
+        OntologyRegistry.load_file(str(METAQA_YAML))
+        circuit = DiscoveryEngine.extract_circuit(
+            "movie",
+            THREE_NODE_EDGES,
+            source={"Nolan": 1.0},
+            sink={"Action": 0.0},
+        )
+        # The two edges (Movie_A→Nolan via directed_by) and (Movie_A→Action via has_genre)
+        # both carry current. Both should survive the default threshold.
+        assert len(circuit) == 2
+        edge_set = {(min(s, t), r, max(s, t)) for s, r, t in circuit}
+        assert ("Movie_A", "directed_by", "Nolan") in edge_set or (
+            "Movie_A",
+            "directed_by",
+            "Nolan",
+        ) in {(s, r, t) for s, r, t in circuit}
+        assert any(r == "has_genre" for _, r, _ in circuit)


### PR DESCRIPTION
Implements DiscoveryEngine with two public methods:

- find_paths: beam search from source to sink guided by edge current G(i,j) × |V(i) - V(j)| as the expansion heuristic. Path score is the bottleneck current (minimum edge current along the path). Numba JIT kernel batch-computes all edge currents in one pass before the beam loop.

- extract_circuit: single-pass filter returning only edges whose current exceeds a threshold. Dead-end branches excluded for free — nodes connected to one side float to that voltage, giving zero potential difference and zero current.

Also adds:
- 30 tests including a pinned numerical test for the 3-node circuit
- demo/demo_discovery.py: Marimo notebook with live interactive demo, loop engineering walkthrough (Keanu Reeves → Crime 2-step field re-solve), and the three-layer stack
- README: full Layer 3 section covering LLM and non-LLM use cases