### PR TITLE
Upgrade to mloda 0.9.0: columnar PythonDict + core allowed_values (closes #29)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ partitions = mloda.run_all(
 )
 
 for partition in partitions:
-    for row in partition:
-        print(row[feature.name])
+    for row in partition.get(feature.name, []):
+        print(row)
 ```
 
 Swap `rdflib_sparql` for any of the nine connector families below: same `Feature` to `mloda.run_all` shape, different reader.

--- a/demo/demo_kg_build_repo.py
+++ b/demo/demo_kg_build_repo.py
@@ -228,7 +228,7 @@ def helpers():
             compute_frameworks={_KgPythonDictFramework},
             data_access_collection=dac,
         )
-        return [row[feat.name] for partition in partitions for row in partition if feat.name in row]
+        return [row for partition in partitions for row in partition.get(feat.name, [])]
 
     return build_graph_to_ttl, run_sparql
 

--- a/demo/demo_kg_connectors.py
+++ b/demo/demo_kg_connectors.py
@@ -78,8 +78,8 @@ def helpers():
         `ReadDB` subclass and selecting the one whose `CONNECTOR_ID` slot is
         present in `credentials`. The KG FG base pins `compute_framework_rule`
         to `KgPythonDictFramework`, the KG-aware adapter that wraps native rows
-        as `{feature_name: row}` during column slicing; we flat-concat across
-        partitions for the per-cell rendering.
+        into a `{feature_name: [row, ...]}` column; we flat-concat that column
+        across partitions for the per-cell rendering.
         """
         dac = _DataAccessCollection(credentials=[{connector_id: slot_creds}])
         partitions = _mloda.run_all(
@@ -87,7 +87,7 @@ def helpers():
             compute_frameworks={_KgPythonDictFramework},
             data_access_collection=dac,
         )
-        return [row[feature.name] for partition in partitions for row in partition if feature.name in row]
+        return [row for partition in partitions for row in partition.get(feature.name, [])]
 
     def fixture_for(module: _Any, *parts: str) -> _Any:
         base = _Path(module.__file__).parent / "tests" / "fixtures"

--- a/demo/demo_kg_ontology.py
+++ b/demo/demo_kg_ontology.py
@@ -364,7 +364,7 @@ def connector_demo(GML_FILE, ONTOLOGY_YAML, mo):
         compute_frameworks={KgPythonDictFramework},
         data_access_collection=_dac,
     )
-    _rows = [row[_feat.name] for part in _partitions for row in part if _feat.name in row]
+    _rows = [row for part in _partitions for row in part.get(_feat.name, [])]
 
     mo.md(f"""
     **mloda.run_all with ontology credential**
@@ -449,7 +449,7 @@ def backend_swap(ONTOLOGY_YAML, OntologyRegistry, mo):
         compute_frameworks={_KgFW},
         data_access_collection=_dac,
     )
-    _kuzu_rows = [row[_feat.name] for part in _partitions for row in part if _feat.name in row]
+    _kuzu_rows = [row for part in _partitions for row in part.get(_feat.name, [])]
 
     # Same ontology YAML, same validation rules — only the credential locator changed.
     _valid_edges = [

--- a/open_kgo/compute_frameworks/python_dict_kg_framework.py
+++ b/open_kgo/compute_frameworks/python_dict_kg_framework.py
@@ -2,19 +2,17 @@
 
 Native KG rows (SPARQL bindings, Cypher rows, REST records, BFS hops, ...)
 have their own keys (``s``, ``p``, ``o``, ``name``, ``ancestor``, ...) — none
-of which match the user-defined feature name. ``PythonDictFramework`` matches
-columns by feature-name presence in each row (see
-``select_data_by_column_names`` in
-``mloda_plugins.compute_framework.base_implementations.python_dict``), so an
-unmatched feature would yield ``[{}, {}, ...]`` and silently lose every row.
+of which match the user-defined feature name. ``PythonDictFramework`` (mloda
+>=0.9.0) stores tabular data COLUMNAR (``dict[str, list]``) and its
+``transform`` pivots a reader's native list-of-row-dicts into that shape, so
+the KG columns would never match the requested feature name and every row
+would be dropped during column selection.
 
-The wrap that satisfies that contract used to live on the universal
-``KgConnectorReaderBase.load``, which made the framework-matching strategy
-leak into every reader regardless of compute framework. This adapter moves
-the wrap into a ``PythonDictFramework`` subclass that owns it as an internal
-concern: ``load_data`` returns native KG rows; this framework wraps them as
-``{feature_name: row}`` immediately before column slicing. Other compute
-frameworks never see the wrap.
+This adapter overrides ``transform`` to instead wrap the native rows into a
+single column named after the requested feature, one cell per row holding the
+whole native row dict. The parent's columnar ``select_data_by_column_names``
+then selects that column unchanged, and each cell is unwrapped by feature name
+downstream. Other compute frameworks never see the wrap.
 
 Pinned by ``KgConnectorFeatureGroupBase.compute_framework_rule`` so every KG
 FeatureGroup runs through this adapter by default.
@@ -22,9 +20,8 @@ FeatureGroup runs through this adapter by default.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
-from mloda.user import FeatureName
 from mloda_plugins.compute_framework.base_implementations.python_dict.python_dict_framework import (
     PythonDictFramework,
 )
@@ -33,61 +30,26 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
 class KgPythonDictFramework(PythonDictFramework):
     """``PythonDictFramework`` that wraps native KG rows under the requested feature name.
 
-    Mirrors the prior universal-base behavior: every row is wrapped as
-    ``{feature_name: row}`` before column slicing, regardless of whether
-    ``feature_name`` already appears as a key in the row. Wrapping
-    unconditionally preserves the historical contract, a row whose own keys
-    happen to collide with the feature name still loses access to the
-    colliding key, but that was already the case under the prior wrap and
-    changing it here would be a silent semantic shift.
-
-    The parent's ``identify_naming_convention`` hook (which supports the
-    ``feature_name~suffix`` multi-column pattern) is intentionally bypassed:
-    after the wrap, every row has exactly one key, the feature name, so
-    convention-based suffix matching has nothing to expand against. Native KG
-    rows have their own keys (``s``, ``p``, ``o``, ...) that never match the
-    user-defined feature name with or without suffixes, so this restriction
-    matches existing reality. KG features that need the suffix pattern would
-    need a different adapter; surfacing that explicitly is preferable to
-    silent loss.
-
-    Empty results are returned as ``[]`` instead of raising. The
-    parent ``PythonDictFramework`` treats ``[]`` as fatal because for tabular
-    data an empty selection is usually a schema-discovery failure (no rows
-    means no column types to infer, no naming convention to expand). KG
-    semantics are different: a SPARQL ``SELECT`` with no matches, a citation
-    lookup against an unknown ``stable_id``, an ``agent_memory`` query that
-    finds nothing, or a ``saas_authz`` filter that excludes every tuple all
-    legitimately return zero rows. Forcing those onto the parent's
-    "empty is fatal" path made ``mloda.run_all`` hostile to data users with
-    real empty-result queries (the prior workaround had to bypass the run
-    entirely). The cardinality and ``column_ordering`` guards still fire
-    even on empty data, because those are caller-shape bugs that are
-    orthogonal to row count.
+    KG concrete ``load_data`` implementations dispatch one feature at a time,
+    so ``transform`` wraps unconditionally under that single feature name,
+    regardless of whether it already appears as a key in the native row (a
+    colliding key still loses direct access, matching the prior wrap). An empty
+    result yields the zero-row single-column frame ``{feature_name: []}``
+    (schema-bearing, not the schema-less ``{}`` mloda rejects), so a SPARQL
+    ``SELECT`` with no matches, a citation lookup against an unknown
+    ``stable_id``, an ``agent_memory`` query that finds nothing, or a
+    ``saas_authz`` filter that excludes every tuple all return zero rows
+    without raising.
     """
 
-    def select_data_by_column_names(
-        self,
-        data: list[dict[str, Any]],
-        selected_feature_names: set[FeatureName],
-        column_ordering: Optional[str] = None,
-    ) -> list[dict[str, Any]]:
-        if len(selected_feature_names) != 1:
+    def transform(self, data: Any, feature_names: set[str]) -> dict[str, list[Any]]:
+        if len(feature_names) != 1:
             raise ValueError(
-                f"{type(self).__name__}.select_data_by_column_names expects exactly one feature per call "
+                f"{type(self).__name__}.transform expects exactly one feature per call "
                 f"(KG concrete load_data implementations all dispatch one feature at a time); "
-                f"the reader's ``load`` should reject this earlier, this branch is defense-in-depth. "
-                f"Got {sorted(str(n) for n in selected_feature_names)}."
+                f"got {sorted(str(n) for n in feature_names)}."
             )
-
-        if column_ordering is not None:
-            raise ValueError(
-                f"{type(self).__name__} does not honor column_ordering "
-                f"(single-feature wrap has no ordering to apply); got {column_ordering!r}."
-            )
-
-        if not data:
-            return []
-
-        feature_name = str(next(iter(selected_feature_names)))
-        return [{feature_name: row} for row in data]
+        if isinstance(data, list):
+            feature_name = str(next(iter(feature_names)))
+            return {feature_name: list(data)}
+        return super().transform(data, feature_names)

--- a/open_kgo/compute_frameworks/tests/test_python_dict_kg_framework.py
+++ b/open_kgo/compute_frameworks/tests/test_python_dict_kg_framework.py
@@ -1,10 +1,11 @@
 """Direct unit tests for ``KgPythonDictFramework``.
 
-The KG-aware ``PythonDictFramework`` adapter wraps native KG rows under the
-requested feature name during column slicing, so the wrap-for-column-matching
-strategy lives in a framework-specific layer instead of leaking into the
-universal ``KgConnectorReaderBase.load``. These tests pin down the adapter's
-public behaviour independently of any concrete connector.
+The KG-aware ``PythonDictFramework`` adapter wraps native KG rows into a single
+column named after the requested feature during ``transform`` (native ->
+columnar), so the wrap-for-column-matching strategy lives in a
+framework-specific layer instead of leaking into the universal
+``KgConnectorReaderBase.load``. These tests pin down the adapter's public
+behaviour independently of any concrete connector.
 """
 
 from __future__ import annotations
@@ -12,7 +13,6 @@ from __future__ import annotations
 import pytest
 
 from mloda.core.abstract_plugins.components.parallelization_modes import ParallelizationMode
-from mloda.user import FeatureName
 
 from open_kgo.compute_frameworks.python_dict_kg_framework import KgPythonDictFramework
 
@@ -29,83 +29,46 @@ def _make_framework() -> KgPythonDictFramework:
     return KgPythonDictFramework(mode=ParallelizationMode.SYNC, children_if_root=frozenset())
 
 
-def test_select_data_wraps_native_rows_under_feature_name() -> None:
-    """Each native row is returned as ``{feature_name: row}``."""
+def test_transform_wraps_native_rows_under_feature_name() -> None:
+    """Native rows become one column keyed by the feature, each cell a full row."""
     fw = _make_framework()
     native_rows = [{"s": "x", "p": "y", "o": "z"}, {"s": "a", "p": "b", "o": "c"}]
-    result = fw.select_data_by_column_names(native_rows, {FeatureName("my_feature")})
-    assert result == [
-        {"my_feature": {"s": "x", "p": "y", "o": "z"}},
-        {"my_feature": {"s": "a", "p": "b", "o": "c"}},
-    ]
+    result = fw.transform(native_rows, {"my_feature"})
+    assert result == {"my_feature": [{"s": "x", "p": "y", "o": "z"}, {"s": "a", "p": "b", "o": "c"}]}
 
 
-def test_select_data_wrap_is_unconditional_even_when_feature_name_collides() -> None:
-    """Wrap mirrors the prior ``KgConnectorReaderBase.load`` semantics: always wrap.
+def test_transform_wrap_is_unconditional_even_when_feature_name_collides() -> None:
+    """Wrap always applies, even when the feature name already appears as a row key.
 
-    Conditional wrapping (skip when the feature name already appears as a
-    row key) would silently change behaviour for the rare collision case.
-    Wrapping unconditionally preserves the historical contract.
+    Conditional wrapping (skip when the feature name is already a row key)
+    would silently change behaviour for the rare collision case.
     """
     fw = _make_framework()
     rows = [{"my_feature": "shadowed", "other": 1}]
-    result = fw.select_data_by_column_names(rows, {FeatureName("my_feature")})
-    assert result == [{"my_feature": {"my_feature": "shadowed", "other": 1}}]
+    result = fw.transform(rows, {"my_feature"})
+    assert result == {"my_feature": [{"my_feature": "shadowed", "other": 1}]}
 
 
-def test_select_data_rejects_multi_feature_call() -> None:
-    """Adapter mirrors the reader's single-feature contract.
-
-    KG readers dispatch one feature at a time; passing two feature names to
-    the framework's column slicer would silently pick one. Reject loudly.
-    """
+def test_transform_rejects_multi_feature_call() -> None:
+    """KG readers dispatch one feature at a time; two feature names is a caller-shape bug."""
     fw = _make_framework()
     with pytest.raises(ValueError):
-        fw.select_data_by_column_names([{"a": 1}], {FeatureName("feat_a"), FeatureName("feat_b")})
+        fw.transform([{"a": 1}], {"feat_a", "feat_b"})
 
 
-def test_select_data_returns_empty_list_for_empty_input() -> None:
-    """Empty input returns ``[]``.
+def test_transform_empty_input_yields_schema_bearing_zero_row_column() -> None:
+    """Empty results return ``{feature_name: []}``, not the schema-less ``{}`` mloda rejects.
 
-    The parent ``PythonDictFramework`` raises on ``[]`` because for tabular
-    data an empty selection is usually a schema-discovery failure. KG
-    semantics differ: a query with no matches is a legitimate outcome, so
-    the adapter relaxes the parent's "empty is fatal" guard. The
-    cardinality and ``column_ordering`` guards are orthogonal and still
-    fire (see the dedicated tests below); this test only pins the
-    relaxation on the data dimension.
+    A KG query with no matches is a legitimate zero-row outcome, but mloda
+    requires a schema (at least one column), so the empty result keeps the
+    feature's column with no rows.
     """
     fw = _make_framework()
-    result = fw.select_data_by_column_names([], {FeatureName("my_feature")})
-    assert result == []
+    assert fw.transform([], {"my_feature"}) == {"my_feature": []}
 
 
-def test_select_data_empty_input_still_rejects_multi_feature_call() -> None:
+def test_transform_empty_input_still_rejects_multi_feature_call() -> None:
     """Cardinality guard fires even on ``[]`` (caller-shape bug is orthogonal to row count)."""
     fw = _make_framework()
     with pytest.raises(ValueError):
-        fw.select_data_by_column_names([], {FeatureName("feat_a"), FeatureName("feat_b")})
-
-
-def test_select_data_empty_input_still_rejects_column_ordering() -> None:
-    """``column_ordering`` guard fires even on ``[]`` (caller-shape bug is orthogonal to row count)."""
-    fw = _make_framework()
-    with pytest.raises(ValueError):
-        fw.select_data_by_column_names([], {FeatureName("my_feature")}, column_ordering="alphabetical")
-
-
-def test_select_data_rejects_column_ordering() -> None:
-    """``column_ordering`` is meaningless for a single-feature wrap; reject loudly.
-
-    The parent ``PythonDictFramework`` honors ``column_ordering`` via
-    ``identify_naming_convention``. The KG adapter bypasses that hook because
-    each wrapped row has exactly one key (the feature name). Silently
-    accepting the parameter would be a lie about supported semantics.
-    """
-    fw = _make_framework()
-    with pytest.raises(ValueError):
-        fw.select_data_by_column_names(
-            [{"a": 1}],
-            {FeatureName("my_feature")},
-            column_ordering="alphabetical",
-        )
+        fw.transform([], {"feat_a", "feat_b"})

--- a/open_kgo/feature_groups/kg/base.py
+++ b/open_kgo/feature_groups/kg/base.py
@@ -14,8 +14,8 @@ now split by concern and re-exported here, so existing import sites
   dict on ``PARAMS_MAPPING``).
 - ``feature_group.py`` owns ``KgConnectorFeatureGroupBase``, the thin
   FeatureGroup that delegates to a reader.
-- ``spec.py`` owns the typed ``PropertySpec`` builder spec dicts are
-  authored through.
+- ``spec.py`` wraps mloda core's ``property_spec`` builder that spec dicts
+  are authored through.
 """
 
 from open_kgo.feature_groups.kg.feature_group import KgConnectorFeatureGroupBase

--- a/open_kgo/feature_groups/kg/credentials.py
+++ b/open_kgo/feature_groups/kg/credentials.py
@@ -153,13 +153,13 @@ def spec_allowed_values(key: str, spec: dict[str, Any]) -> set[Any]:
     """Return the explicit ``allowed_values`` set declared on a strict-validation spec.
 
     Strict-validation specs must declare their value space explicitly via
-    an ``allowed_values`` field (a dict mapping value to its docstring, or
-    any iterable of values). Deriving the set from the spec's plain string
-    keys would silently expand the allowed set whenever a future doc-only
-    key like ``"see_also"`` is added; the explicit field separates docs
-    from validation data.
+    the core ``DefaultOptionKeys.allowed_values`` field (a dict mapping value
+    to its docstring, or any iterable of values). Deriving the set from the
+    spec's plain string keys would silently expand the allowed set whenever a
+    future doc-only key like ``"see_also"`` is added; the explicit field
+    separates docs from validation data.
     """
-    raw = spec.get("allowed_values")
+    raw = spec.get(DefaultOptionKeys.allowed_values)
     if raw is None:
         raise InvalidCredentialShape(
             f"spec for {key!r} declares strict_validation=True but is missing 'allowed_values'."

--- a/open_kgo/feature_groups/kg/reader_base.py
+++ b/open_kgo/feature_groups/kg/reader_base.py
@@ -435,7 +435,7 @@ class KgConnectorReaderBase(ReadDB):
         (every concrete in this package satisfies that). The shape check below
         turns a future drift (a concrete returning a single dict, ``None``, or
         a generator) into a typed error here rather than an indirect failure
-        downstream in ``select_data_by_column_names``.
+        downstream in ``KgPythonDictFramework.transform``.
         """
         self._assert_single_feature(features)
         result = super().load(features)

--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -1,88 +1,22 @@
-"""Typed builder for ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` spec dicts.
+"""Thin KG wrapper over mloda core's ``property_spec`` PROPERTY_MAPPING builder.
 
-mloda's property-mapping convention keeps the mapping values as plain dicts
-(``FeatureGroup.PROPERTY_MAPPING`` is typed ``dict[str, Any]`` and mloda core
-reads it as such; see mloda's ``docs/in_depth/property-mapping.md``), so this
-module does not change what a spec IS. It changes how a spec is AUTHORED:
-``PropertySpec`` validates its own invariants at construction time and then
-emits the conventional dict via ``to_mapping``, so a malformed spec (a strict
-enum with no ``allowed_values``, an ``allowed_values`` on a non-strict key
-that would never be enforced, a strict default outside its own allowed set)
-fails at import time with a named error instead of surfacing later as a
-confusing validation result.
-
-Consumers (``_validate_mapping``, ``_spec_allowed_values``, the discovery
-helpers in ``tests/_discovery.py``) keep reading plain dicts; sites that
-derive a spec from an existing one (e.g. ``InProcessTupleStoreReader``'s
-``tenant`` override) keep using dict spreads. Only fresh literals route
-through the builder.
+mloda>=0.9.0 ships ``mloda.provider.property_spec`` plus the first-class
+``DefaultOptionKeys.allowed_values`` field, so open-kgo no longer maintains its
+own copy of the builder/validation (see mloda-ai/open-kgo#29). Core validates
+the spec's invariants; this wrapper only preserves one open-kgo convention core
+does not: ``default`` is always emitted (explicit ``None`` when unset) so KG
+specs read uniformly via subscript across the validation/discovery/contract
+layer. The extra key is in core's ``RESERVED_PROPERTY_KEYS`` and so is ignored
+by core's own spec parser.
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import Any, Iterable, Mapping
+from collections.abc import Iterable, Mapping
+from typing import Any
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-
-
-@dataclass(frozen=True)
-class PropertySpec:
-    """One credential/param key's spec, validated at construction.
-
-    ``allowed_values`` is usually a ``Mapping`` of value to one-line docstring
-    (the shape every KG family uses); a plain iterable of values is also
-    accepted, mirroring ``_spec_allowed_values``. The object passes through to
-    the emitted dict unchanged so downstream readers (including
-    ``bogus_value_for_strict_spec``'s ``isinstance(raw, dict)`` branch) see
-    exactly what was authored.
-    """
-
-    explanation: str
-    strict: bool = False
-    allowed_values: Mapping[Any, str] | Iterable[Any] | None = None
-    default: Any = None
-    context: bool = True
-
-    def __post_init__(self) -> None:
-        if self.allowed_values is not None and not isinstance(self.allowed_values, Mapping):
-            # Materialize one-shot iterables (e.g. a generator) up front: the
-            # emptiness and default-membership checks below iterate the value,
-            # and an exhausted iterator would otherwise be emitted into the
-            # spec dict and behave like an empty enum that rejects everything.
-            object.__setattr__(self, "allowed_values", tuple(self.allowed_values))
-        if self.strict and not self.allowed_values:
-            raise ValueError(
-                f"PropertySpec({self.explanation!r}): strict=True requires a non-empty allowed_values; "
-                f"a strict enum with no value space rejects everything."
-            )
-        if not self.strict and self.allowed_values is not None:
-            raise ValueError(
-                f"PropertySpec({self.explanation!r}): allowed_values without strict=True would never be "
-                f"enforced by _validate_mapping; either set strict=True or drop allowed_values."
-            )
-        if self.strict and self.default is not None:
-            allowed = (
-                set(self.allowed_values.keys())
-                if isinstance(self.allowed_values, Mapping)
-                else set(self.allowed_values or ())
-            )
-            if self.default not in allowed:
-                raise ValueError(
-                    f"PropertySpec({self.explanation!r}): default {self.default!r} is not in the "
-                    f"allowed set {sorted(allowed, key=repr)}; an omitted key would default to a "
-                    f"value the validator then rejects."
-                )
-
-    def to_mapping(self) -> dict[str, Any]:
-        """Emit the mloda-conventional spec dict this dataclass describes."""
-        out: dict[str, Any] = {"explanation": self.explanation}
-        if self.allowed_values is not None:
-            out["allowed_values"] = self.allowed_values
-        out[DefaultOptionKeys.context] = self.context
-        out[DefaultOptionKeys.strict_validation] = self.strict
-        out[DefaultOptionKeys.default] = self.default
-        return out
+from mloda.provider import property_spec as _core_property_spec
 
 
 def property_spec(
@@ -93,11 +27,13 @@ def property_spec(
     default: Any = None,
     context: bool = True,
 ) -> dict[str, Any]:
-    """Build and emit a spec dict in one expression (the common authoring case)."""
-    return PropertySpec(
-        explanation=explanation,
+    """Build a PROPERTY_MAPPING spec dict via core, keeping ``default`` always present."""
+    spec = _core_property_spec(
+        explanation,
         strict=strict,
         allowed_values=allowed_values,
         default=default,
         context=context,
-    ).to_mapping()
+    )
+    spec.setdefault(DefaultOptionKeys.default, None)
+    return spec

--- a/open_kgo/feature_groups/kg/tests/_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/_helpers.py
@@ -41,13 +41,12 @@ def run_query(connector_id: str, slot_creds: dict[str, Any], feature: Feature) -
     The selected
     reader's ``load`` returns native KG rows; ``KgPythonDictFramework``
     (pinned by ``KgConnectorFeatureGroupBase.compute_framework_rule``) wraps
-    each row as ``{feature_name: row}`` during column slicing so this helper
-    can unwrap by feature name and return the underlying row values flattened
-    across partitions.
+    them into a single ``{feature_name: [row, ...]}`` column, so each
+    partition is that columnar dict and this helper unwraps the feature's
+    column and flattens the native rows across partitions.
 
-    Zero-result queries return ``[]``: the adapter passes empty
-    data through unchanged, so the comprehension below contributes no rows
-    and the helper yields ``[]`` to the caller.
+    Zero-result queries return ``[]``: an empty result is the zero-row
+    ``{feature_name: []}`` partition, whose column contributes no rows.
     """
     dac = DataAccessCollection(credentials=[{connector_id: slot_creds}])
     partitions = mloda.run_all(
@@ -55,7 +54,7 @@ def run_query(connector_id: str, slot_creds: dict[str, Any], feature: Feature) -
         compute_frameworks={KgPythonDictFramework},
         data_access_collection=dac,
     )
-    return [row[feature.name] for partition in partitions for row in partition if feature.name in row]
+    return [row for partition in partitions for row in partition.get(feature.name, [])]
 
 
 def make_valid_credentials(

--- a/open_kgo/feature_groups/kg/tests/contract_load.py
+++ b/open_kgo/feature_groups/kg/tests/contract_load.py
@@ -119,7 +119,7 @@ class LoadBehaviorContract(KgContractAdapterBase):
         Covers ``CONNECTOR_ID`` matching, ``is_valid_credentials``, the
         ``DataAccessCollection`` wiring, and ``KgPythonDictFramework`` row
         consumption (the KG-aware ``PythonDictFramework`` adapter that wraps
-        native rows as ``{feature_name: row}`` during column slicing). A
+        native rows into a ``{feature_name: [row, ...]}`` column). A
         regression in any of these surfaces here.
 
         Pre-check that ``is_valid_credentials`` accepts

--- a/open_kgo/feature_groups/kg/tests/test_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/test_helpers.py
@@ -14,7 +14,8 @@ Covers the test-library helpers exposed by ``_helpers``:
   contract-base signature change.
 - ``run_query`` zero-result paths: the prior
   ``run_query_allowing_empty`` workaround is retired now that the framework
-  adapter passes ``[]`` through unchanged. The end-to-end assertions live
+  adapter emits the zero-row ``{feature_name: []}`` frame for empty
+  results instead of raising. The end-to-end assertions live
   in ``test_run_query_returns_empty_list_for_unknown_stable_id`` and
   ``test_run_query_returns_native_rows_when_present`` below; they exercise
   the full ``mloda.run_all`` path instead of the direct-load shortcut.
@@ -278,12 +279,10 @@ def test_make_valid_credentials_validate_true_rejects_closed_world_violation() -
 def test_run_query_returns_empty_list_for_unknown_stable_id() -> None:
     """An unknown ``stable_id`` is a legitimate zero-result path; we get ``[]``, not a raise.
 
-    Before the empty-result relaxation, ``run_query`` flowed through
-    ``KgPythonDictFramework.select_data_by_column_names`` which rejected
-    ``[]`` with the parent ``PythonDictFramework``'s "Data cannot be empty"
-    guard. The adapter now passes empty data through unchanged so the
-    full ``mloda.run_all`` path is usable for legitimate zero-result
-    queries.
+    ``KgPythonDictFramework.transform`` emits the zero-row
+    ``{feature_name: []}`` frame for an empty result (schema-bearing, so
+    mloda does not raise ``EmptyResultError``), keeping the full
+    ``mloda.run_all`` path usable for legitimate zero-result queries.
 
     Dogfoods ``make_valid_credentials`` (B5) to build the slot so both
     helpers exercise each other in the same test.

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -1,8 +1,9 @@
-"""Tests for the typed property-spec builder (``kg/spec.py``).
+"""Tests for the KG ``property_spec`` wrapper (``kg/spec.py``).
 
-The builder's value is twofold: it emits exactly the mloda-conventional dict
-shape the validators and discovery helpers read, and it rejects malformed
-specs at construction time. Both halves are pinned here.
+The wrapper delegates construction and invariant validation to mloda core
+(``mloda.provider.property_spec``); these tests pin the one open-kgo-specific
+behavior it adds (``default`` always emitted) and confirm core's validation is
+in force through the wrapper.
 """
 
 from __future__ import annotations
@@ -11,7 +12,7 @@ import pytest
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 
-from open_kgo.feature_groups.kg.spec import PropertySpec, property_spec
+from open_kgo.feature_groups.kg.spec import property_spec
 
 
 class TestPropertySpecEmission:
@@ -34,14 +35,9 @@ class TestPropertySpecEmission:
         assert emitted[DefaultOptionKeys.default] == "a"
 
     def test_omitted_default_emits_none(self) -> None:
-        """Absence of ``default`` means an explicit ``None``, matching the repo convention."""
+        """The wrapper always emits ``default`` (explicit ``None``); core omits it when None."""
         emitted = property_spec("An optional key.")
         assert emitted[DefaultOptionKeys.default] is None
-
-    def test_dataclass_and_helper_agree(self) -> None:
-        """``property_spec`` is exactly ``PropertySpec(...).to_mapping()``."""
-        kwargs: dict[str, object] = {"strict": True, "allowed_values": {"x": "Doc."}, "default": "x"}
-        assert property_spec("Same.", **kwargs) == PropertySpec("Same.", **kwargs).to_mapping()  # type: ignore[arg-type]
 
 
 class TestPropertySpecInvariants:
@@ -50,15 +46,15 @@ class TestPropertySpecInvariants:
             property_spec("Strict but empty.", strict=True)
 
     def test_strict_with_empty_allowed_values_rejected(self) -> None:
-        with pytest.raises(ValueError, match="non-empty allowed_values"):
+        with pytest.raises(ValueError, match="empty allowed_values would reject"):
             property_spec("Strict but empty.", strict=True, allowed_values={})
 
     def test_allowed_values_without_strict_rejected(self) -> None:
-        with pytest.raises(ValueError, match="never be"):
+        with pytest.raises(ValueError, match="never enforced"):
             property_spec("Decorative enum.", allowed_values={"a": "Doc."})
 
     def test_strict_default_outside_allowed_set_rejected(self) -> None:
-        with pytest.raises(ValueError, match="not in the"):
+        with pytest.raises(ValueError, match="not in the accepted set"):
             property_spec("Bad default.", strict=True, allowed_values={"a": "Doc."}, default="z")
 
     def test_strict_none_default_permitted(self) -> None:
@@ -67,22 +63,16 @@ class TestPropertySpecInvariants:
         assert emitted[DefaultOptionKeys.default] is None
 
     def test_iterable_allowed_values_accepted(self) -> None:
-        """Plain iterables mirror ``_spec_allowed_values``; the default check still applies."""
+        """Plain iterables mirror ``spec_allowed_values``; the default check still applies."""
         emitted = property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="b")
         assert emitted["allowed_values"] == ("a", "b")
-        with pytest.raises(ValueError, match="not in the"):
+        with pytest.raises(ValueError, match="not in the accepted set"):
             property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="z")
 
     def test_generator_allowed_values_materialized(self) -> None:
-        """A one-shot iterable is materialized, not emitted exhausted (codex review finding).
-
-        Without materialization, ``__post_init__`` consumes the generator and
-        ``to_mapping`` would emit a dead iterator that behaves like an empty
-        enum, silently rejecting every value downstream.
-        """
+        """A one-shot iterable is materialized, not emitted exhausted."""
         emitted = property_spec("Generator enum.", strict=True, allowed_values=(v for v in ("a", "b")), default="a")
         assert emitted["allowed_values"] == ("a", "b")
-        # An exhausted-empty generator is rejected like any other empty allowed set.
         no_values: tuple[str, ...] = ()
-        with pytest.raises(ValueError, match="non-empty allowed_values"):
+        with pytest.raises(ValueError, match="empty allowed_values would reject"):
             property_spec("Empty generator.", strict=True, allowed_values=(v for v in no_values))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "open-kgo"
 # semantic-release bumps the latest git tag; needs a `0.2.0` tag pushed once by
-# hand to bootstrap. The mloda floor (>=0.8.0) is unrelated.
+# hand to bootstrap. The mloda floor (>=0.9.0) is unrelated.
 version = "0.2.2"
 description = "Open Knowledge Graphs and Ontologies plugin for mloda."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "tomkaltofen@mloda.ai" }]
-dependencies = ["mloda>=0.8.0"]
+dependencies = ["mloda>=0.9.0"]
 requires-python = ">=3.10"
 # No `License ::` trove classifier: `license` above is an SPDX expression
 # (PEP 639) and setuptools rejects both together.

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -220,7 +220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -646,10 +646,10 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.8.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/d8/b4f8beceec599fe75b4956fc8614ead1d40bc0642e6562c18c2c683f2685/mloda-0.8.0-py3-none-any.whl", hash = "sha256:521e0425169a99370b3d1cdf9fd480ebecb3f9a0ec67c62fe6a321ca8e3bcabe", size = 428976, upload-time = "2026-06-05T17:24:09.732Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/82/a7893ddd9ab26dd839671c594e9c16437364a8b8ed5dffb02e9b2de52d7f/mloda-0.9.0-py3-none-any.whl", hash = "sha256:d193b03622e6c8670ccde500c9e6d74eba9ef4ed70ca3bd6adbcb9330a370585", size = 430826, upload-time = "2026-07-07T08:48:32.032Z" },
 ]
 
 [[package]]
@@ -895,7 +895,7 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'kg-embedded'", specifier = ">=0.11" },
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
-    { name = "mloda", specifier = ">=0.8.0" },
+    { name = "mloda", specifier = ">=0.9.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.1" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },
@@ -1190,7 +1190,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
## Summary

Upgrade open-kgo to the newest mloda (**0.9.0**, up from a `>=0.8.0` floor) and adapt to the two behavior changes it ships, plus adopt the now-unblocked `allowed_values` field.

### 1. Columnar PythonDict (mloda 0.9.0)
0.9.0 stores tabular data as `dict[str, list]` and its `transform` pivots a reader's native rows into columnar **before** column selection; it also rejects a schema-less `{}` result (zero columns) with `EmptyResultError`.

- The KG "wrap each native row under the feature name" trick moved from a row-wise `select_data_by_column_names` override into a `transform` override that wraps native rows into a single `{feature_name: [row, ...]}` column. The parent's columnar `select_data_by_column_names` then selects it.
- Empty results now return the schema-bearing zero-row `{feature_name: []}` frame instead of the rejected `{}`.
- `run_query` (test helper) and the README quickstart + all three demo scripts were updated to unwrap the columnar column.

### 2. Adopt core `allowed_values` / `property_spec` (closes #29)
mloda#562 (shipped in 0.9.0) adds a first-class `allowed_values` PROPERTY_MAPPING field and a `property_spec` builder in `mloda.provider`, which unblocks #29.

- Retired open-kgo's duplicated `PropertySpec` dataclass + validation; `spec.py` is now a thin wrapper over `mloda.provider.property_spec` that preserves open-kgo's "`default` always present" convention (a KG-specific emit convention core does not have).
- `credentials.spec_allowed_values` reads the core `DefaultOptionKeys.allowed_values` field.

The `class_guards.py` guards and `reader_base` compose/narrow helpers are **kept**: they enforce KG-specific cross-field invariants (SUPPORTED_VALUES subset, SOURCE_SLOT, REQUIRED_KEYS omission-bypass, waivers) that core does not provide, so the issue's "remove redundant guards" item does not apply.

## Testing
- `tox` green: 1007 passed, 57 skipped; `ruff format`, `ruff check`, `mypy --strict`, `bandit` all pass.
- README quickstart verified end-to-end against the columnar output.

## Review
Two independent deep reviews (Claude Opus + codex). Both confirmed the core logic; codex caught the README/demo consumers still on the old row-wise shape (not covered by the tox gate), now fixed; stale docstrings referencing the removed `PropertySpec` / old wrap were refreshed.

Closes #29.