### PR TITLE
refactor: split reader_base composition and ontology DC-circuit solver

### DIFF
--- a/open_kgo/feature_groups/kg/base.py
+++ b/open_kgo/feature_groups/kg/base.py
@@ -9,8 +9,7 @@ now split by concern and re-exported here, so existing import sites
   "Honest credential surface" rule and the "Source-slot convention") are
   documented on that module's docstring.
 - ``composition.py`` owns the property-mapping composition helpers
-  (``compose_property_mapping`` / ``narrow_property_mapping``) that
-  ``reader_base.py``'s family-base composition delegates to.
+  (``compose_property_mapping`` / ``narrow_property_mapping``).
 - ``readers.py`` owns the two per-call input flavors a family base picks
   between: ``QueryReader`` (query string) and ``ParamReader`` (typed param
   dict on ``PARAMS_MAPPING``).

--- a/open_kgo/feature_groups/kg/base.py
+++ b/open_kgo/feature_groups/kg/base.py
@@ -4,11 +4,13 @@ The universal base layer used to live in this module as one large file; it is
 now split by concern and re-exported here, so existing import sites
 (``from open_kgo.feature_groups.kg.base import ...``) keep working unchanged:
 
-- ``reader_base.py`` owns ``LoadContext``, the property-mapping composition
-  helpers (``compose_property_mapping`` / ``narrow_property_mapping``), and
-  ``KgConnectorReaderBase``. The conceptual rules referenced across the
-  package as "see base.py" (the "Honest credential surface" rule and the
-  "Source-slot convention") are documented on that module's docstring.
+- ``reader_base.py`` owns ``LoadContext`` and ``KgConnectorReaderBase``. The
+  conceptual rules referenced across the package as "see base.py" (the
+  "Honest credential surface" rule and the "Source-slot convention") are
+  documented on that module's docstring.
+- ``composition.py`` owns the property-mapping composition helpers
+  (``compose_property_mapping`` / ``narrow_property_mapping``) that
+  ``reader_base.py``'s family-base composition delegates to.
 - ``readers.py`` owns the two per-call input flavors a family base picks
   between: ``QueryReader`` (query string) and ``ParamReader`` (typed param
   dict on ``PARAMS_MAPPING``).
@@ -27,13 +29,12 @@ from mloda_plugins.compute_framework.base_implementations.python_dict.python_dic
     PythonDictFramework,
 )
 
+from open_kgo.feature_groups.kg.composition import compose_property_mapping, narrow_property_mapping
 from open_kgo.feature_groups.kg.feature_group import KgConnectorFeatureGroupBase
 from open_kgo.feature_groups.kg.reader_base import (
     KgConnectorReaderBase,
     LoadContext,
     _collect_kg_known_keys,
-    compose_property_mapping,
-    narrow_property_mapping,
 )
 from open_kgo.feature_groups.kg.readers import ParamReader, QueryReader
 

--- a/open_kgo/feature_groups/kg/composition.py
+++ b/open_kgo/feature_groups/kg/composition.py
@@ -1,12 +1,7 @@
 """Family-surface composition helpers for KG connector readers.
 
-Runtime companion to the two class-definition-time/runtime concern modules
-``kg.class_guards`` and ``kg.credentials``: this module owns the
-``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` composition machinery that
-``KgConnectorReaderBase.__init_subclass__`` (in ``reader_base.py``) delegates
-to. Extracted from ``reader_base.py`` so that module stays focused on the
-reader lifecycle; see its module docstring for the concern-module split this
-belongs to.
+Extracted from ``reader_base.py``; sibling concern modules are
+``class_guards.py`` and ``credentials.py``.
 """
 
 from __future__ import annotations
@@ -20,23 +15,7 @@ if TYPE_CHECKING:
 
 
 def compose_property_mapping(*sources: dict[str, Any], context: str = "") -> dict[str, Any]:
-    """Merge property-mapping dicts and raise on duplicate keys.
-
-    Replaces the spread-merge ``{**A, **B, **C}`` idiom used by family bases.
-    The spread-merge silently overwrites duplicates; this helper raises
-    ``PropertyMappingCollision`` so structural collisions surface at import
-    time. ``context`` is the family/mixin name carried into the error message.
-
-    Also rejects non-dict spec values at composition time via
-    ``NonDictSpecError``. A ``None`` spec would otherwise pass downstream
-    ``mapping.get(key) is None`` lookups and surface as a self-contradicting
-    "unknown credential key" error: the key is listed in ``allowed`` but
-    ``_validate_mapping`` cannot distinguish a missing key from a ``None``
-    spec via ``.get``. Catching it here keeps the closed-world check honest.
-    ``NonDictSpecError`` is a sibling of ``PropertyMappingCollision`` under
-    ``InvalidCredentialShape`` so callers can scope a single typed handler
-    across the whole structural-error family.
-    """
+    """Merge property-mapping dicts, raising on duplicate keys or non-dict spec values."""
     merged: dict[str, Any] = {}
     for source in sources:
         for key, spec in source.items():
@@ -49,17 +28,7 @@ def compose_property_mapping(*sources: dict[str, Any], context: str = "") -> dic
 
 
 def narrow_property_mapping(source: dict[str, Any], *exclude: str) -> dict[str, Any]:
-    """Return ``source`` minus the ``exclude`` keys — the narrowing companion to ``compose_property_mapping``.
-
-    Concrete plugins drop family-level keys they do not honor (advertising
-    a key the reader ignores would be a surface lie that the closed-world
-    credential check then rejects). This is option 1 of the "Honest credential
-    surface" rule in ``reader_base``'s module docstring. Several concretes
-    spelled this as an inline ``{k: v for k, v in Parent.PROPERTY_MAPPING.items()
-    if k not in {...}}`` comprehension; centralising it names the intent and
-    keeps the narrowing rule in one place. Keys in ``exclude`` that are absent
-    from ``source`` are silently ignored (narrowing is idempotent).
-    """
+    """Return ``source`` minus the ``exclude`` keys."""
     excluded = set(exclude)
     return {k: v for k, v in source.items() if k not in excluded}
 
@@ -69,45 +38,7 @@ def compose_family_surface(
     family_properties: dict[str, Any],
     family_params: dict[str, Any],
 ) -> None:
-    """Auto-compose ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` for a family base.
-
-    Family bases used to spell the same ritual: ``PROPERTY_MAPPING =
-    compose_property_mapping(Parent.PROPERTY_MAPPING, Mixin.PROPERTY_
-    MAPPING_DELTA, {family keys}, context=...)`` and a parallel call for
-    ``PARAMS_MAPPING``, which made it possible to inherit a mixin yet
-    forget to merge one of its delta layers. Declaring the surface as
-    class keyword arguments instead::
-
-        class CitationRestReader(PaginationMixin, ParamReader,
-                                 family_properties={...},
-                                 family_params={...}):
-
-    routes through here (via ``KgConnectorReaderBase.__init_subclass__``):
-    the inherited mapping (the parent reader's), every
-    ``PROPERTY_MAPPING_DELTA`` / ``PARAMS_MAPPING_DELTA`` found in the MRO
-    (the declared mixins), and the family keys are composed with
-    ``compose_property_mapping`` (duplicate keys raise, as before) before
-    the class-definition guards run.
-
-    Rules:
-    - Opt-in: only classes passing ``family_properties`` and/or
-      ``family_params`` are touched; concrete plugins keep assembling
-      their narrowed mappings explicitly in the class body.
-    - Mixing styles is rejected: a class that opts in must not also
-      assign either mapping in its class body (the body value would
-      silently win over the parent/mixin layers).
-    - ``PARAMS_MAPPING`` is composed only for readers that have the
-      attribute (``ParamReader`` descendants). A ``QueryReader`` family
-      may inherit a mixin with a params delta (agent_memory inherits
-      ``PaginationMixin``); the delta is deliberately ignored because the
-      flavor has no ``build_params`` to honor it, and passing
-      ``family_params`` on such a family raises.
-    - Deltas are collected from the WHOLE MRO. A future family base that
-      subclasses another family base which already absorbed a mixin would
-      re-collect that mixin's delta and fail loudly with a
-      ``PropertyMappingCollision`` at import; such a chain needs explicit
-      composition instead of this opt-in.
-    """
+    """Compose ``PROPERTY_MAPPING``/``PARAMS_MAPPING`` for a family base from parent, mixin deltas, and family keys."""
     for layer in ("PROPERTY_MAPPING", "PARAMS_MAPPING"):
         if layer in cls.__dict__:
             raise ValueError(
@@ -132,10 +63,7 @@ def compose_family_surface(
         klass.__dict__["PARAMS_MAPPING_DELTA"] for klass in cls.__mro__ if "PARAMS_MAPPING_DELTA" in klass.__dict__
     ]
     if params_deltas or family_params:
-        # setattr because PARAMS_MAPPING is declared on ParamReader, not on
-        # this universal base; the getattr gate above already proved cls is
-        # a params-flavored reader.
-        setattr(  # noqa: B010
+        setattr(  # noqa: B010 -- PARAMS_MAPPING is declared on ParamReader, not this base
             cls,
             "PARAMS_MAPPING",
             compose_property_mapping(

--- a/open_kgo/feature_groups/kg/composition.py
+++ b/open_kgo/feature_groups/kg/composition.py
@@ -1,0 +1,144 @@
+"""Family-surface composition helpers for KG connector readers.
+
+Runtime companion to the two class-definition-time/runtime concern modules
+``kg.class_guards`` and ``kg.credentials``: this module owns the
+``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` composition machinery that
+``KgConnectorReaderBase.__init_subclass__`` (in ``reader_base.py``) delegates
+to. Extracted from ``reader_base.py`` so that module stays focused on the
+reader lifecycle; see its module docstring for the concern-module split this
+belongs to.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from open_kgo.feature_groups.kg.errors import NonDictSpecError, PropertyMappingCollision
+
+if TYPE_CHECKING:
+    from open_kgo.feature_groups.kg.reader_base import KgConnectorReaderBase
+
+
+def compose_property_mapping(*sources: dict[str, Any], context: str = "") -> dict[str, Any]:
+    """Merge property-mapping dicts and raise on duplicate keys.
+
+    Replaces the spread-merge ``{**A, **B, **C}`` idiom used by family bases.
+    The spread-merge silently overwrites duplicates; this helper raises
+    ``PropertyMappingCollision`` so structural collisions surface at import
+    time. ``context`` is the family/mixin name carried into the error message.
+
+    Also rejects non-dict spec values at composition time via
+    ``NonDictSpecError``. A ``None`` spec would otherwise pass downstream
+    ``mapping.get(key) is None`` lookups and surface as a self-contradicting
+    "unknown credential key" error: the key is listed in ``allowed`` but
+    ``_validate_mapping`` cannot distinguish a missing key from a ``None``
+    spec via ``.get``. Catching it here keeps the closed-world check honest.
+    ``NonDictSpecError`` is a sibling of ``PropertyMappingCollision`` under
+    ``InvalidCredentialShape`` so callers can scope a single typed handler
+    across the whole structural-error family.
+    """
+    merged: dict[str, Any] = {}
+    for source in sources:
+        for key, spec in source.items():
+            if key in merged:
+                raise PropertyMappingCollision(key, context=context)
+            if not isinstance(spec, dict):
+                raise NonDictSpecError(key, spec, context=context)
+            merged[key] = spec
+    return merged
+
+
+def narrow_property_mapping(source: dict[str, Any], *exclude: str) -> dict[str, Any]:
+    """Return ``source`` minus the ``exclude`` keys — the narrowing companion to ``compose_property_mapping``.
+
+    Concrete plugins drop family-level keys they do not honor (advertising
+    a key the reader ignores would be a surface lie that the closed-world
+    credential check then rejects). This is option 1 of the "Honest credential
+    surface" rule in ``reader_base``'s module docstring. Several concretes
+    spelled this as an inline ``{k: v for k, v in Parent.PROPERTY_MAPPING.items()
+    if k not in {...}}`` comprehension; centralising it names the intent and
+    keeps the narrowing rule in one place. Keys in ``exclude`` that are absent
+    from ``source`` are silently ignored (narrowing is idempotent).
+    """
+    excluded = set(exclude)
+    return {k: v for k, v in source.items() if k not in excluded}
+
+
+def compose_family_surface(
+    cls: type["KgConnectorReaderBase"],
+    family_properties: dict[str, Any],
+    family_params: dict[str, Any],
+) -> None:
+    """Auto-compose ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` for a family base.
+
+    Family bases used to spell the same ritual: ``PROPERTY_MAPPING =
+    compose_property_mapping(Parent.PROPERTY_MAPPING, Mixin.PROPERTY_
+    MAPPING_DELTA, {family keys}, context=...)`` and a parallel call for
+    ``PARAMS_MAPPING``, which made it possible to inherit a mixin yet
+    forget to merge one of its delta layers. Declaring the surface as
+    class keyword arguments instead::
+
+        class CitationRestReader(PaginationMixin, ParamReader,
+                                 family_properties={...},
+                                 family_params={...}):
+
+    routes through here (via ``KgConnectorReaderBase.__init_subclass__``):
+    the inherited mapping (the parent reader's), every
+    ``PROPERTY_MAPPING_DELTA`` / ``PARAMS_MAPPING_DELTA`` found in the MRO
+    (the declared mixins), and the family keys are composed with
+    ``compose_property_mapping`` (duplicate keys raise, as before) before
+    the class-definition guards run.
+
+    Rules:
+    - Opt-in: only classes passing ``family_properties`` and/or
+      ``family_params`` are touched; concrete plugins keep assembling
+      their narrowed mappings explicitly in the class body.
+    - Mixing styles is rejected: a class that opts in must not also
+      assign either mapping in its class body (the body value would
+      silently win over the parent/mixin layers).
+    - ``PARAMS_MAPPING`` is composed only for readers that have the
+      attribute (``ParamReader`` descendants). A ``QueryReader`` family
+      may inherit a mixin with a params delta (agent_memory inherits
+      ``PaginationMixin``); the delta is deliberately ignored because the
+      flavor has no ``build_params`` to honor it, and passing
+      ``family_params`` on such a family raises.
+    - Deltas are collected from the WHOLE MRO. A future family base that
+      subclasses another family base which already absorbed a mixin would
+      re-collect that mixin's delta and fail loudly with a
+      ``PropertyMappingCollision`` at import; such a chain needs explicit
+      composition instead of this opt-in.
+    """
+    for layer in ("PROPERTY_MAPPING", "PARAMS_MAPPING"):
+        if layer in cls.__dict__:
+            raise ValueError(
+                f"{cls.__name__} passes family_properties/family_params but also assigns {layer} "
+                f"in its class body; declare the surface one way only."
+            )
+    property_deltas = [
+        klass.__dict__["PROPERTY_MAPPING_DELTA"] for klass in cls.__mro__ if "PROPERTY_MAPPING_DELTA" in klass.__dict__
+    ]
+    cls.PROPERTY_MAPPING = compose_property_mapping(
+        cls.PROPERTY_MAPPING, *property_deltas, family_properties, context=cls.__name__
+    )
+    params_mapping = getattr(cls, "PARAMS_MAPPING", None)
+    if params_mapping is None:
+        if family_params:
+            raise ValueError(
+                f"{cls.__name__} passes family_params but is not a ParamReader descendant; "
+                f"query-flavored families have no PARAMS_MAPPING layer."
+            )
+        return
+    params_deltas = [
+        klass.__dict__["PARAMS_MAPPING_DELTA"] for klass in cls.__mro__ if "PARAMS_MAPPING_DELTA" in klass.__dict__
+    ]
+    if params_deltas or family_params:
+        # setattr because PARAMS_MAPPING is declared on ParamReader, not on
+        # this universal base; the getattr gate above already proved cls is
+        # a params-flavored reader.
+        setattr(  # noqa: B010
+            cls,
+            "PARAMS_MAPPING",
+            compose_property_mapping(
+                params_mapping, *params_deltas, family_params, context=f"{cls.__name__}.PARAMS_MAPPING"
+            ),
+        )

--- a/open_kgo/feature_groups/kg/ontology/dc_solver.py
+++ b/open_kgo/feature_groups/kg/ontology/dc_solver.py
@@ -108,7 +108,7 @@ def filter_edges(
     return [(s, r, t) for s, r, t in edges if r == relation_type]
 
 
-def build_laplacian(
+def _build_laplacian(
     nodes: list[str],
     edges: list[tuple[str, str, str]],
     namespace: str,
@@ -133,7 +133,7 @@ def build_laplacian(
     return L
 
 
-def solve_dirichlet(
+def _solve_dirichlet(
     L: list[list[float]],
     interior: list[int],
     boundary: dict[int, float],
@@ -205,8 +205,8 @@ def compute_field(
     boundary = {idx[e]: v for e, v in anchors.items() if e in idx}
     interior = [i for i in range(len(nodes)) if i not in boundary]
 
-    L = build_laplacian(nodes, edges, namespace)
-    V_interior = solve_dirichlet(L, interior, boundary)
+    L = _build_laplacian(nodes, edges, namespace)
+    V_interior = _solve_dirichlet(L, interior, boundary)
 
     result: dict[str, float] = {}
     for e, v in anchors.items():

--- a/open_kgo/feature_groups/kg/ontology/dc_solver.py
+++ b/open_kgo/feature_groups/kg/ontology/dc_solver.py
@@ -1,0 +1,217 @@
+"""Shared DC circuit primitives for the ontology-grounded scoring layers.
+
+Both ``semantic_field.SemanticField`` (Layer 2) and ``discovery.DiscoveryEngine``
+(Layer 3) solve the same conductance-weighted graph Laplacian and read edge
+conductances off the same ontology-declared weights; this module is the one
+place that math lives. Layer 3 needs the solved potentials Layer 2 already
+knows how to compute, so it depends on this module rather than reaching into
+``semantic_field``'s internals.
+
+  - Edge conductance  = ontology-declared relationship weight  (G = w)
+  - Edge resistance   = inverse weight                         (R = 1/w)
+  - Query anchors     = Dirichlet boundary conditions          (fixed voltage)
+
+The potential is solved via the conductance-weighted graph Laplacian:
+
+    L · V = s
+
+where L[i,i] = Σ G(i,j) over all neighbours j,  L[i,j] = -G(i,j),
+and the known anchor voltages are applied as Dirichlet boundary conditions
+(standard impressed-voltage treatment from electrical network theory).
+
+Reference: Kirchhoff matrix / graph Laplacian for resistor networks
+(Strang, Introduction to Linear Algebra ch. 10; verified against
+MIT OCW 18.06 and Berkeley Stat260/CS294 lecture notes on spectral graph
+methods; effective-resistance formulation from Ghosh & Boyd, Stanford 2006).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
+
+# ---------------------------------------------------------------------------
+# Optional numba acceleration for the Gaussian elimination kernel.
+# Falls back to pure Python when numba / numpy are not installed.
+# ---------------------------------------------------------------------------
+
+_np_mod: Any = None
+_nb_solve: Any = None  # compiled kernel: (aug: ndarray) -> ndarray
+
+try:
+    import numpy as _numba_np
+    from numba import njit as _njit
+
+    @_njit(cache=True)
+    def _nb_gauss_elim(aug):  # type: ignore[no-untyped-def]
+        """Gaussian elimination with partial pivoting on an augmented matrix.
+
+        Operates in-place on ``aug`` (shape m × m+1, float64).
+        Returns the solution vector V of length m.
+        """
+        m = aug.shape[0]
+        for col in range(m):
+            pivot = col
+            for r in range(col + 1, m):
+                if abs(aug[r, col]) > abs(aug[pivot, col]):
+                    pivot = r
+            for c in range(m + 1):
+                tmp = aug[col, c]
+                aug[col, c] = aug[pivot, c]
+                aug[pivot, c] = tmp
+            if abs(aug[col, col]) < 1e-12:
+                continue
+            for r in range(col + 1, m):
+                f = aug[r, col] / aug[col, col]
+                for c in range(col, m + 1):
+                    aug[r, c] -= f * aug[col, c]
+        V = _numba_np.zeros(m)
+        for row in range(m - 1, -1, -1):
+            if abs(aug[row, row]) < 1e-12:
+                V[row] = 0.0
+                continue
+            V[row] = aug[row, m]
+            for c in range(row + 1, m):
+                V[row] -= aug[row, c] * V[c]
+            V[row] /= aug[row, row]
+        return V
+
+    _np_mod = _numba_np
+    _nb_solve = _nb_gauss_elim
+
+except ImportError:
+    pass
+
+
+def conductance(namespace: str, relation: str) -> float:
+    """Return the conductance for ``relation`` in ``namespace``.
+
+    Conductance = declared ontology weight. Falls back to 1.0 when no
+    ontology is registered or the relation is not declared (open-world
+    assumption — unknown edges are treated as unit conductors).
+    """
+    ontology = OntologyRegistry.get(namespace)
+    if ontology is None:
+        return 1.0
+    rule = ontology.relationships.get(relation)
+    return rule.weight if rule is not None else 1.0
+
+
+def filter_edges(
+    edges: list[tuple[str, str, str]],
+    relation_type: str | None,
+) -> list[tuple[str, str, str]]:
+    """Return edges restricted to ``relation_type``, or all edges if None."""
+    if relation_type is None:
+        return list(edges)
+    return [(s, r, t) for s, r, t in edges if r == relation_type]
+
+
+def build_laplacian(
+    nodes: list[str],
+    edges: list[tuple[str, str, str]],
+    namespace: str,
+) -> list[list[float]]:
+    """Return the conductance-weighted graph Laplacian as a 2-D list.
+
+    Edges are treated as undirected — current flows both ways through a
+    resistor regardless of the semantic direction of the relationship.
+    """
+    n = len(nodes)
+    idx = {node: i for i, node in enumerate(nodes)}
+    L: list[list[float]] = [[0.0] * n for _ in range(n)]
+    for src, relation, tgt in edges:
+        if src not in idx or tgt not in idx:
+            continue
+        g = conductance(namespace, relation)
+        i, j = idx[src], idx[tgt]
+        L[i][j] -= g
+        L[j][i] -= g
+        L[i][i] += g
+        L[j][j] += g
+    return L
+
+
+def solve_dirichlet(
+    L: list[list[float]],
+    interior: list[int],
+    boundary: dict[int, float],
+) -> list[float]:
+    """Solve L_II · V_I = -L_IB · V_B via Gaussian elimination.
+
+    Implements the standard Dirichlet decomposition for resistor networks:
+    partition nodes into boundary B (known voltage) and interior I (unknown),
+    then solve the reduced system. Zero-pivot rows (disconnected nodes)
+    receive potential 0.0.
+    """
+    m = len(interior)
+    if m == 0:
+        return []
+
+    aug: list[list[float]] = []
+    for row_idx in interior:
+        aug_row: list[float] = [L[row_idx][col_idx] for col_idx in interior]
+        rhs_val = -sum(L[row_idx][b] * v for b, v in boundary.items())
+        aug_row.append(rhs_val)
+        aug.append(aug_row)
+
+    # Numba-compiled path (when numba + numpy are available)
+    if _nb_solve is not None:
+        aug_arr = _np_mod.array(aug, dtype=_np_mod.float64)
+        return list(_nb_solve(aug_arr))
+
+    # Pure-Python fallback — forward elimination with partial pivoting
+    for col in range(m):
+        pivot_row = col
+        for r in range(col + 1, m):
+            if abs(aug[r][col]) > abs(aug[pivot_row][col]):
+                pivot_row = r
+        aug[col], aug[pivot_row] = aug[pivot_row], aug[col]
+        if abs(aug[col][col]) < 1e-12:
+            continue
+        for r in range(col + 1, m):
+            factor = aug[r][col] / aug[col][col]
+            for c in range(col, m + 1):
+                aug[r][c] -= factor * aug[col][c]
+
+    # Back substitution
+    V: list[float] = [0.0] * m
+    for row in range(m - 1, -1, -1):
+        if abs(aug[row][row]) < 1e-12:
+            V[row] = 0.0
+            continue
+        V[row] = aug[row][m]
+        for col in range(row + 1, m):
+            V[row] -= aug[row][col] * V[col]
+        V[row] /= aug[row][row]
+
+    return V
+
+
+def compute_field(
+    namespace: str,
+    edges: list[tuple[str, str, str]],
+    anchors: dict[str, float],
+) -> dict[str, float]:
+    """Core field computation (no edge filtering — callers filter first)."""
+    nodes_set: set[str] = set(anchors)
+    for src, _, tgt in edges:
+        nodes_set.add(src)
+        nodes_set.add(tgt)
+    nodes = sorted(nodes_set)
+    idx = {node: i for i, node in enumerate(nodes)}
+
+    boundary = {idx[e]: v for e, v in anchors.items() if e in idx}
+    interior = [i for i in range(len(nodes)) if i not in boundary]
+
+    L = build_laplacian(nodes, edges, namespace)
+    V_interior = solve_dirichlet(L, interior, boundary)
+
+    result: dict[str, float] = {}
+    for e, v in anchors.items():
+        if e in idx:
+            result[e] = v
+    for k, i in enumerate(interior):
+        result[nodes[i]] = V_interior[k]
+    return result

--- a/open_kgo/feature_groups/kg/ontology/dc_solver.py
+++ b/open_kgo/feature_groups/kg/ontology/dc_solver.py
@@ -1,28 +1,9 @@
-"""Shared DC circuit primitives for the ontology-grounded scoring layers.
+"""Shared DC circuit primitives for the ontology scoring layers.
 
-Both ``semantic_field.SemanticField`` (Layer 2) and ``discovery.DiscoveryEngine``
-(Layer 3) solve the same conductance-weighted graph Laplacian and read edge
-conductances off the same ontology-declared weights; this module is the one
-place that math lives. Layer 3 needs the solved potentials Layer 2 already
-knows how to compute, so it depends on this module rather than reaching into
-``semantic_field``'s internals.
-
-  - Edge conductance  = ontology-declared relationship weight  (G = w)
-  - Edge resistance   = inverse weight                         (R = 1/w)
-  - Query anchors     = Dirichlet boundary conditions          (fixed voltage)
-
-The potential is solved via the conductance-weighted graph Laplacian:
-
-    L · V = s
-
-where L[i,i] = Σ G(i,j) over all neighbours j,  L[i,j] = -G(i,j),
-and the known anchor voltages are applied as Dirichlet boundary conditions
-(standard impressed-voltage treatment from electrical network theory).
-
-Reference: Kirchhoff matrix / graph Laplacian for resistor networks
-(Strang, Introduction to Linear Algebra ch. 10; verified against
-MIT OCW 18.06 and Berkeley Stat260/CS294 lecture notes on spectral graph
-methods; effective-resistance formulation from Ghosh & Boyd, Stanford 2006).
+Solves the conductance-weighted graph Laplacian ``L * V = s`` with anchor
+voltages as Dirichlet boundary conditions. Used by both
+``semantic_field.SemanticField`` (Layer 2) and ``discovery.DiscoveryEngine``
+(Layer 3).
 """
 
 from __future__ import annotations
@@ -31,11 +12,8 @@ from typing import Any
 
 from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
 
-# ---------------------------------------------------------------------------
-# Optional numba acceleration for the Gaussian elimination kernel.
-# Falls back to pure Python when numba / numpy are not installed.
-# ---------------------------------------------------------------------------
-
+# Optional numba acceleration for the Gaussian elimination kernel; falls back
+# to pure Python when numba / numpy are not installed.
 _np_mod: Any = None
 _nb_solve: Any = None  # compiled kernel: (aug: ndarray) -> ndarray
 
@@ -45,11 +23,7 @@ try:
 
     @_njit(cache=True)
     def _nb_gauss_elim(aug):  # type: ignore[no-untyped-def]
-        """Gaussian elimination with partial pivoting on an augmented matrix.
-
-        Operates in-place on ``aug`` (shape m × m+1, float64).
-        Returns the solution vector V of length m.
-        """
+        """Gaussian elimination with partial pivoting on an augmented matrix (in-place, m x m+1)."""
         m = aug.shape[0]
         for col in range(m):
             pivot = col
@@ -85,12 +59,7 @@ except ImportError:
 
 
 def conductance(namespace: str, relation: str) -> float:
-    """Return the conductance for ``relation`` in ``namespace``.
-
-    Conductance = declared ontology weight. Falls back to 1.0 when no
-    ontology is registered or the relation is not declared (open-world
-    assumption — unknown edges are treated as unit conductors).
-    """
+    """Return the declared ontology weight for ``relation``, or 1.0 if unknown/unregistered."""
     ontology = OntologyRegistry.get(namespace)
     if ontology is None:
         return 1.0
@@ -113,11 +82,7 @@ def _build_laplacian(
     edges: list[tuple[str, str, str]],
     namespace: str,
 ) -> list[list[float]]:
-    """Return the conductance-weighted graph Laplacian as a 2-D list.
-
-    Edges are treated as undirected — current flows both ways through a
-    resistor regardless of the semantic direction of the relationship.
-    """
+    """Return the conductance-weighted graph Laplacian as a 2-D list (edges treated as undirected)."""
     n = len(nodes)
     idx = {node: i for i, node in enumerate(nodes)}
     L: list[list[float]] = [[0.0] * n for _ in range(n)]
@@ -138,13 +103,7 @@ def _solve_dirichlet(
     interior: list[int],
     boundary: dict[int, float],
 ) -> list[float]:
-    """Solve L_II · V_I = -L_IB · V_B via Gaussian elimination.
-
-    Implements the standard Dirichlet decomposition for resistor networks:
-    partition nodes into boundary B (known voltage) and interior I (unknown),
-    then solve the reduced system. Zero-pivot rows (disconnected nodes)
-    receive potential 0.0.
-    """
+    """Solve L_II * V_I = -L_IB * V_B via Gaussian elimination (boundary = known voltages, interior = unknowns)."""
     m = len(interior)
     if m == 0:
         return []
@@ -156,12 +115,11 @@ def _solve_dirichlet(
         aug_row.append(rhs_val)
         aug.append(aug_row)
 
-    # Numba-compiled path (when numba + numpy are available)
     if _nb_solve is not None:
         aug_arr = _np_mod.array(aug, dtype=_np_mod.float64)
         return list(_nb_solve(aug_arr))
 
-    # Pure-Python fallback — forward elimination with partial pivoting
+    # Pure-Python fallback: forward elimination with partial pivoting, then back substitution.
     for col in range(m):
         pivot_row = col
         for r in range(col + 1, m):
@@ -175,7 +133,6 @@ def _solve_dirichlet(
             for c in range(col, m + 1):
                 aug[r][c] -= factor * aug[col][c]
 
-    # Back substitution
     V: list[float] = [0.0] * m
     for row in range(m - 1, -1, -1):
         if abs(aug[row][row]) < 1e-12:

--- a/open_kgo/feature_groups/kg/ontology/discovery.py
+++ b/open_kgo/feature_groups/kg/ontology/discovery.py
@@ -1,6 +1,7 @@
 """DC circuit beam search over the EM potential landscape (Layer 3).
 
-SemanticField (Layer 2) pre-computes:
+The sibling ``dc_solver`` module (shared with ``semantic_field.SemanticField``,
+Layer 2) pre-computes:
 
   - V[e]: electric potential at every entity (solved via graph Laplacian)
   - Implied edge current: G(i,j) × |V(i) - V(j)|
@@ -34,7 +35,7 @@ import math
 from dataclasses import dataclass
 from typing import Any
 
-from open_kgo.feature_groups.kg.ontology.semantic_field import _compute_field, _conductance
+from open_kgo.feature_groups.kg.ontology.dc_solver import compute_field, conductance
 
 # ---------------------------------------------------------------------------
 # Optional numba acceleration for batch edge-current computation.
@@ -124,7 +125,7 @@ def _compute_edge_currents(
     if _nb_edge_currents is not None and _np_mod is not None:
         v_src_list = [voltages.get(e[0], 0.0) for e in edges]
         v_tgt_list = [voltages.get(e[2], 0.0) for e in edges]
-        cond_list = [_conductance(namespace, e[1]) for e in edges]
+        cond_list = [conductance(namespace, e[1]) for e in edges]
         v_src_arr = _np_mod.array(v_src_list, dtype=_np_mod.float64)
         v_tgt_arr = _np_mod.array(v_tgt_list, dtype=_np_mod.float64)
         cond_arr = _np_mod.array(cond_list, dtype=_np_mod.float64)
@@ -137,7 +138,7 @@ def _compute_edge_currents(
                 result[(t, s)] = c
     else:
         for s, r, t in edges:
-            g = _conductance(namespace, r)
+            g = conductance(namespace, r)
             c = g * abs(voltages.get(s, 0.0) - voltages.get(t, 0.0))
             if c > result.get((s, t), 0.0):
                 result[(s, t)] = c
@@ -219,7 +220,7 @@ class DiscoveryEngine:
             return []
 
         combined_anchors: dict[str, float] = {**sink, **source}
-        voltages = _compute_field(namespace, edges, combined_anchors)
+        voltages = compute_field(namespace, edges, combined_anchors)
         neighbor_edges = _build_neighbor_edges(edges)
         edge_current = _compute_edge_currents(namespace, edges, voltages)
 
@@ -312,11 +313,11 @@ class DiscoveryEngine:
             return []
 
         combined_anchors: dict[str, float] = {**sink, **source}
-        voltages = _compute_field(namespace, edges, combined_anchors)
+        voltages = compute_field(namespace, edges, combined_anchors)
 
         result: list[tuple[str, str, str]] = []
         for s, r, t in edges:
-            g = _conductance(namespace, r)
+            g = conductance(namespace, r)
             c = g * abs(voltages.get(s, 0.0) - voltages.get(t, 0.0))
             if c > current_threshold:
                 result.append((s, r, t))

--- a/open_kgo/feature_groups/kg/ontology/models.py
+++ b/open_kgo/feature_groups/kg/ontology/models.py
@@ -1,0 +1,86 @@
+"""Ontology data model and YAML parsing for ``OntologyRegistry``.
+
+Extracted from ``registry.py`` so that module stays focused on the
+process-wide cache/lookup concern; this module owns the shape of a parsed
+ontology file and the parser itself.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class RelationshipRule:
+    """Domain and range type constraints for one relationship type."""
+
+    domain: str
+    range_type: str
+    weight: float = 1.0
+
+
+@dataclass
+class NamespaceOntology:
+    """All ontology rules for one namespace / domain."""
+
+    namespace: str
+    entity_valid_outgoing: dict[str, frozenset[str]]
+    relationships: dict[str, RelationshipRule]
+
+    def is_valid_edge(self, entity_type: str, relationship: str) -> bool:
+        """Return True if ``relationship`` is a valid outgoing edge from ``entity_type``.
+
+        Unknown entity types pass through (True) so connectors that carry
+        entities not declared in the ontology are not silently broken.
+        """
+        valid = self.entity_valid_outgoing.get(entity_type)
+        if valid is None:
+            return True
+        return relationship in valid
+
+    def get_range_type(self, relationship: str) -> str | None:
+        """Return the entity type at the far end of ``relationship``, or None."""
+        rule = self.relationships.get(relationship)
+        return rule.range_type if rule else None
+
+    def valid_next_hops(self, entity_type: str) -> frozenset[str]:
+        """Return the set of valid outgoing relationship types for ``entity_type``."""
+        return self.entity_valid_outgoing.get(entity_type, frozenset())
+
+
+def parse_ontology(data: Any) -> NamespaceOntology:
+    """Parse a loaded YAML mapping into a ``NamespaceOntology``.
+
+    Raises ``ValueError`` (the same error type ``OntologyRegistry.load_file``
+    documents for duplicate namespaces) on a malformed file — a non-mapping
+    top level, a missing ``namespace``, or a relationship that omits its
+    ``domain`` / ``range`` — so a bad ontology surfaces a clear, typed
+    error rather than a raw ``KeyError`` / ``TypeError`` from indexing.
+    """
+    if not isinstance(data, dict):
+        raise ValueError(f"ontology file must contain a YAML mapping at the top level, got {type(data).__name__}.")
+    if "namespace" not in data:
+        raise ValueError("ontology file is missing the required 'namespace' key.")
+    namespace = str(data["namespace"])
+
+    entity_valid_outgoing: dict[str, frozenset[str]] = {}
+    for name, spec in (data.get("entities") or {}).items():
+        valid_outgoing = spec.get("valid_outgoing") if isinstance(spec, dict) else None
+        entity_valid_outgoing[str(name)] = frozenset(valid_outgoing or [])
+
+    relationships: dict[str, RelationshipRule] = {}
+    for name, spec in (data.get("relationships") or {}).items():
+        if not isinstance(spec, dict) or "domain" not in spec or "range" not in spec:
+            raise ValueError(f"ontology relationship {name!r} must be a mapping declaring both 'domain' and 'range'.")
+        relationships[str(name)] = RelationshipRule(
+            domain=str(spec["domain"]),
+            range_type=str(spec["range"]),
+            weight=float(spec.get("weight", 1.0)),
+        )
+
+    return NamespaceOntology(
+        namespace=namespace,
+        entity_valid_outgoing=entity_valid_outgoing,
+        relationships=relationships,
+    )

--- a/open_kgo/feature_groups/kg/ontology/models.py
+++ b/open_kgo/feature_groups/kg/ontology/models.py
@@ -1,9 +1,4 @@
-"""Ontology data model and YAML parsing for ``OntologyRegistry``.
-
-Extracted from ``registry.py`` so that module stays focused on the
-process-wide cache/lookup concern; this module owns the shape of a parsed
-ontology file and the parser itself.
-"""
+"""Ontology data model and YAML parsing for ``OntologyRegistry``."""
 
 from __future__ import annotations
 
@@ -29,11 +24,7 @@ class NamespaceOntology:
     relationships: dict[str, RelationshipRule]
 
     def is_valid_edge(self, entity_type: str, relationship: str) -> bool:
-        """Return True if ``relationship`` is a valid outgoing edge from ``entity_type``.
-
-        Unknown entity types pass through (True) so connectors that carry
-        entities not declared in the ontology are not silently broken.
-        """
+        """True if ``relationship`` is a valid outgoing edge from ``entity_type`` (unknown types pass through)."""
         valid = self.entity_valid_outgoing.get(entity_type)
         if valid is None:
             return True
@@ -50,14 +41,7 @@ class NamespaceOntology:
 
 
 def parse_ontology(data: Any) -> NamespaceOntology:
-    """Parse a loaded YAML mapping into a ``NamespaceOntology``.
-
-    Raises ``ValueError`` (the same error type ``OntologyRegistry.load_file``
-    documents for duplicate namespaces) on a malformed file — a non-mapping
-    top level, a missing ``namespace``, or a relationship that omits its
-    ``domain`` / ``range`` — so a bad ontology surfaces a clear, typed
-    error rather than a raw ``KeyError`` / ``TypeError`` from indexing.
-    """
+    """Parse a loaded YAML mapping into a ``NamespaceOntology``; raises ``ValueError`` on a malformed file."""
     if not isinstance(data, dict):
         raise ValueError(f"ontology file must contain a YAML mapping at the top level, got {type(data).__name__}.")
     if "namespace" not in data:

--- a/open_kgo/feature_groups/kg/ontology/registry.py
+++ b/open_kgo/feature_groups/kg/ontology/registry.py
@@ -8,7 +8,9 @@ Loads a YAML ontology definition file and provides lookups for:
 The registry is keyed by namespace so rules are reusable across any connector
 or dataset that operates in the same domain (e.g. every movie KG shares the
 ``movie`` namespace ontology regardless of whether it lives in Neo4j, NetworkX,
-or RDF).
+or RDF). The parsed ontology shape (``NamespaceOntology`` / ``RelationshipRule``)
+and the YAML parser live in the sibling ``models`` module; this module owns the
+process-wide cache and namespace/path lookup.
 
 Usage::
 
@@ -20,47 +22,10 @@ Usage::
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, ClassVar
 
-
-@dataclass(frozen=True)
-class RelationshipRule:
-    """Domain and range type constraints for one relationship type."""
-
-    domain: str
-    range_type: str
-    weight: float = 1.0
-
-
-@dataclass
-class NamespaceOntology:
-    """All ontology rules for one namespace / domain."""
-
-    namespace: str
-    entity_valid_outgoing: dict[str, frozenset[str]]
-    relationships: dict[str, RelationshipRule]
-
-    def is_valid_edge(self, entity_type: str, relationship: str) -> bool:
-        """Return True if ``relationship`` is a valid outgoing edge from ``entity_type``.
-
-        Unknown entity types pass through (True) so connectors that carry
-        entities not declared in the ontology are not silently broken.
-        """
-        valid = self.entity_valid_outgoing.get(entity_type)
-        if valid is None:
-            return True
-        return relationship in valid
-
-    def get_range_type(self, relationship: str) -> str | None:
-        """Return the entity type at the far end of ``relationship``, or None."""
-        rule = self.relationships.get(relationship)
-        return rule.range_type if rule else None
-
-    def valid_next_hops(self, entity_type: str) -> frozenset[str]:
-        """Return the set of valid outgoing relationship types for ``entity_type``."""
-        return self.entity_valid_outgoing.get(entity_type, frozenset())
+from open_kgo.feature_groups.kg.ontology.models import NamespaceOntology, parse_ontology
 
 
 class OntologyRegistry:
@@ -118,42 +83,8 @@ class OntologyRegistry:
 
     @classmethod
     def _parse(cls, data: Any) -> NamespaceOntology:
-        """Parse a loaded YAML mapping into a ``NamespaceOntology``.
-
-        Raises ``ValueError`` (the same error type ``load_file`` already
-        documents for duplicate namespaces) on a malformed file — a non-mapping
-        top level, a missing ``namespace``, or a relationship that omits its
-        ``domain`` / ``range`` — so a bad ontology surfaces a clear, typed
-        error rather than a raw ``KeyError`` / ``TypeError`` from indexing.
-        """
-        if not isinstance(data, dict):
-            raise ValueError(f"ontology file must contain a YAML mapping at the top level, got {type(data).__name__}.")
-        if "namespace" not in data:
-            raise ValueError("ontology file is missing the required 'namespace' key.")
-        namespace = str(data["namespace"])
-
-        entity_valid_outgoing: dict[str, frozenset[str]] = {}
-        for name, spec in (data.get("entities") or {}).items():
-            valid_outgoing = spec.get("valid_outgoing") if isinstance(spec, dict) else None
-            entity_valid_outgoing[str(name)] = frozenset(valid_outgoing or [])
-
-        relationships: dict[str, RelationshipRule] = {}
-        for name, spec in (data.get("relationships") or {}).items():
-            if not isinstance(spec, dict) or "domain" not in spec or "range" not in spec:
-                raise ValueError(
-                    f"ontology relationship {name!r} must be a mapping declaring both 'domain' and 'range'."
-                )
-            relationships[str(name)] = RelationshipRule(
-                domain=str(spec["domain"]),
-                range_type=str(spec["range"]),
-                weight=float(spec.get("weight", 1.0)),
-            )
-
-        return NamespaceOntology(
-            namespace=namespace,
-            entity_valid_outgoing=entity_valid_outgoing,
-            relationships=relationships,
-        )
+        """Parse a loaded YAML mapping into a ``NamespaceOntology``; see ``models.parse_ontology``."""
+        return parse_ontology(data)
 
     @classmethod
     def get(cls, namespace: str) -> NamespaceOntology | None:

--- a/open_kgo/feature_groups/kg/ontology/registry.py
+++ b/open_kgo/feature_groups/kg/ontology/registry.py
@@ -8,9 +8,7 @@ Loads a YAML ontology definition file and provides lookups for:
 The registry is keyed by namespace so rules are reusable across any connector
 or dataset that operates in the same domain (e.g. every movie KG shares the
 ``movie`` namespace ontology regardless of whether it lives in Neo4j, NetworkX,
-or RDF). The parsed ontology shape (``NamespaceOntology`` / ``RelationshipRule``)
-and the YAML parser live in the sibling ``models`` module; this module owns the
-process-wide cache and namespace/path lookup.
+or RDF). Parsed shapes and the YAML parser live in the sibling ``models`` module.
 
 Usage::
 

--- a/open_kgo/feature_groups/kg/ontology/registry.py
+++ b/open_kgo/feature_groups/kg/ontology/registry.py
@@ -25,7 +25,11 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, ClassVar
 
-from open_kgo.feature_groups.kg.ontology.models import NamespaceOntology, parse_ontology
+from open_kgo.feature_groups.kg.ontology.models import (
+    NamespaceOntology,
+    RelationshipRule,  # noqa: F401 -- back-compat re-export, moved to models.py
+    parse_ontology,
+)
 
 
 class OntologyRegistry:

--- a/open_kgo/feature_groups/kg/ontology/semantic_field.py
+++ b/open_kgo/feature_groups/kg/ontology/semantic_field.py
@@ -1,19 +1,11 @@
 """DC circuit semantic field for ontology-grounded query scoring (Layer 2).
 
-Models the knowledge graph as a resistor network:
+Models the knowledge graph as a resistor network; the Laplacian construction
+and Dirichlet solve live in the sibling ``dc_solver`` module (shared with
+``discovery.DiscoveryEngine``, Layer 3, which reuses the same solved
+potentials). This module owns the public scoring API:
 
-  - Edge conductance  = ontology-declared relationship weight  (G = w)
-  - Edge resistance   = inverse weight                         (R = 1/w)
-  - Query anchors     = Dirichlet boundary conditions          (fixed voltage)
   - Semantic field    = electric potential V(entity) at every node
-
-The potential is solved via the conductance-weighted graph Laplacian:
-
-    L · V = s
-
-where L[i,i] = Σ G(i,j) over all neighbours j,  L[i,j] = -G(i,j),
-and the known anchor voltages are applied as Dirichlet boundary conditions
-(standard impressed-voltage treatment from electrical network theory).
 
 For a multi-constraint AND query (``compute_and``) each constraint specifies
 a relationship-type filter together with its anchor set.  Each constraint is
@@ -28,209 +20,11 @@ series path is an open circuit.
 Ontology weights shape the potential when an entity sits between two anchors
 at different voltages.  A higher-conductance path (higher weight) pulls the
 intermediate node's potential closer to the high-voltage anchor.
-
-Reference: Kirchhoff matrix / graph Laplacian for resistor networks
-(Strang, Introduction to Linear Algebra ch. 10; verified against
-MIT OCW 18.06 and Berkeley Stat260/CS294 lecture notes on spectral graph
-methods; effective-resistance formulation from Ghosh & Boyd, Stanford 2006).
 """
 
 from __future__ import annotations
 
-from typing import Any
-
-from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
-
-# ---------------------------------------------------------------------------
-# Optional numba acceleration for the Gaussian elimination kernel.
-# Falls back to pure Python when numba / numpy are not installed.
-# ---------------------------------------------------------------------------
-
-_np_mod: Any = None
-_nb_solve: Any = None  # compiled kernel: (aug: ndarray) -> ndarray
-
-try:
-    import numpy as _numba_np
-    from numba import njit as _njit
-
-    @_njit(cache=True)
-    def _nb_gauss_elim(aug):  # type: ignore[no-untyped-def]
-        """Gaussian elimination with partial pivoting on an augmented matrix.
-
-        Operates in-place on ``aug`` (shape m × m+1, float64).
-        Returns the solution vector V of length m.
-        """
-        m = aug.shape[0]
-        for col in range(m):
-            pivot = col
-            for r in range(col + 1, m):
-                if abs(aug[r, col]) > abs(aug[pivot, col]):
-                    pivot = r
-            for c in range(m + 1):
-                tmp = aug[col, c]
-                aug[col, c] = aug[pivot, c]
-                aug[pivot, c] = tmp
-            if abs(aug[col, col]) < 1e-12:
-                continue
-            for r in range(col + 1, m):
-                f = aug[r, col] / aug[col, col]
-                for c in range(col, m + 1):
-                    aug[r, c] -= f * aug[col, c]
-        V = _numba_np.zeros(m)
-        for row in range(m - 1, -1, -1):
-            if abs(aug[row, row]) < 1e-12:
-                V[row] = 0.0
-                continue
-            V[row] = aug[row, m]
-            for c in range(row + 1, m):
-                V[row] -= aug[row, c] * V[c]
-            V[row] /= aug[row, row]
-        return V
-
-    _np_mod = _numba_np
-    _nb_solve = _nb_gauss_elim
-
-except ImportError:
-    pass
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _conductance(namespace: str, relation: str) -> float:
-    """Return the conductance for ``relation`` in ``namespace``.
-
-    Conductance = declared ontology weight.  Falls back to 1.0 when no
-    ontology is registered or the relation is not declared (open-world
-    assumption — unknown edges are treated as unit conductors).
-    """
-    ontology = OntologyRegistry.get(namespace)
-    if ontology is None:
-        return 1.0
-    rule = ontology.relationships.get(relation)
-    return rule.weight if rule is not None else 1.0
-
-
-def _filter_edges(
-    edges: list[tuple[str, str, str]],
-    relation_type: str | None,
-) -> list[tuple[str, str, str]]:
-    """Return edges restricted to ``relation_type``, or all edges if None."""
-    if relation_type is None:
-        return list(edges)
-    return [(s, r, t) for s, r, t in edges if r == relation_type]
-
-
-def _build_laplacian(
-    nodes: list[str],
-    edges: list[tuple[str, str, str]],
-    namespace: str,
-) -> list[list[float]]:
-    """Return the conductance-weighted graph Laplacian as a 2-D list.
-
-    Edges are treated as undirected — current flows both ways through a
-    resistor regardless of the semantic direction of the relationship.
-    """
-    n = len(nodes)
-    idx = {node: i for i, node in enumerate(nodes)}
-    L: list[list[float]] = [[0.0] * n for _ in range(n)]
-    for src, relation, tgt in edges:
-        if src not in idx or tgt not in idx:
-            continue
-        g = _conductance(namespace, relation)
-        i, j = idx[src], idx[tgt]
-        L[i][j] -= g
-        L[j][i] -= g
-        L[i][i] += g
-        L[j][j] += g
-    return L
-
-
-def _solve_dirichlet(
-    L: list[list[float]],
-    interior: list[int],
-    boundary: dict[int, float],
-) -> list[float]:
-    """Solve L_II · V_I = -L_IB · V_B via Gaussian elimination.
-
-    Implements the standard Dirichlet decomposition for resistor networks:
-    partition nodes into boundary B (known voltage) and interior I (unknown),
-    then solve the reduced system.  Zero-pivot rows (disconnected nodes)
-    receive potential 0.0.
-    """
-    m = len(interior)
-    if m == 0:
-        return []
-
-    aug: list[list[float]] = []
-    for row_idx in interior:
-        aug_row: list[float] = [L[row_idx][col_idx] for col_idx in interior]
-        rhs_val = -sum(L[row_idx][b] * v for b, v in boundary.items())
-        aug_row.append(rhs_val)
-        aug.append(aug_row)
-
-    # Numba-compiled path (when numba + numpy are available)
-    if _nb_solve is not None:
-        aug_arr = _np_mod.array(aug, dtype=_np_mod.float64)
-        return list(_nb_solve(aug_arr))
-
-    # Pure-Python fallback — forward elimination with partial pivoting
-    for col in range(m):
-        pivot_row = col
-        for r in range(col + 1, m):
-            if abs(aug[r][col]) > abs(aug[pivot_row][col]):
-                pivot_row = r
-        aug[col], aug[pivot_row] = aug[pivot_row], aug[col]
-        if abs(aug[col][col]) < 1e-12:
-            continue
-        for r in range(col + 1, m):
-            factor = aug[r][col] / aug[col][col]
-            for c in range(col, m + 1):
-                aug[r][c] -= factor * aug[col][c]
-
-    # Back substitution
-    V: list[float] = [0.0] * m
-    for row in range(m - 1, -1, -1):
-        if abs(aug[row][row]) < 1e-12:
-            V[row] = 0.0
-            continue
-        V[row] = aug[row][m]
-        for col in range(row + 1, m):
-            V[row] -= aug[row][col] * V[col]
-        V[row] /= aug[row][row]
-
-    return V
-
-
-def _compute_field(
-    namespace: str,
-    edges: list[tuple[str, str, str]],
-    anchors: dict[str, float],
-) -> dict[str, float]:
-    """Core field computation (no edge filtering — callers filter first)."""
-    nodes_set: set[str] = set(anchors)
-    for src, _, tgt in edges:
-        nodes_set.add(src)
-        nodes_set.add(tgt)
-    nodes = sorted(nodes_set)
-    idx = {node: i for i, node in enumerate(nodes)}
-
-    boundary = {idx[e]: v for e, v in anchors.items() if e in idx}
-    interior = [i for i in range(len(nodes)) if i not in boundary]
-
-    L = _build_laplacian(nodes, edges, namespace)
-    V_interior = _solve_dirichlet(L, interior, boundary)
-
-    result: dict[str, float] = {}
-    for e, v in anchors.items():
-        if e in idx:
-            result[e] = v
-    for k, i in enumerate(interior):
-        result[nodes[i]] = V_interior[k]
-    return result
-
+from open_kgo.feature_groups.kg.ontology.dc_solver import compute_field, conductance, filter_edges
 
 # ---------------------------------------------------------------------------
 # Public API
@@ -286,8 +80,8 @@ class SemanticField:
             Anchors carry their declared voltage exactly.
             Unreachable entities receive 0.0.
         """
-        filtered = _filter_edges(edges, relation_type)
-        return _compute_field(namespace, filtered, anchors)
+        filtered = filter_edges(edges, relation_type)
+        return compute_field(namespace, filtered, anchors)
 
     @staticmethod
     def compute_and(
@@ -351,11 +145,11 @@ class SemanticField:
         Carries current 0.9 * (1.0 - 0.5625) = 0.394.  Score > 0.
         """
         combined_anchors: dict[str, float] = {**sink, **source}
-        potentials = _compute_field(namespace, edges, combined_anchors)
+        potentials = compute_field(namespace, edges, combined_anchors)
 
         adj: dict[str, dict[str, float]] = {}
         for src, relation, tgt in edges:
-            g = _conductance(namespace, relation)
+            g = conductance(namespace, relation)
             adj.setdefault(src, {})[tgt] = adj.get(src, {}).get(tgt, 0.0) + g
             adj.setdefault(tgt, {})[src] = adj.get(tgt, {}).get(src, 0.0) + g
 

--- a/open_kgo/feature_groups/kg/ontology/semantic_field.py
+++ b/open_kgo/feature_groups/kg/ontology/semantic_field.py
@@ -1,11 +1,8 @@
 """DC circuit semantic field for ontology-grounded query scoring (Layer 2).
 
-Models the knowledge graph as a resistor network; the Laplacian construction
-and Dirichlet solve live in the sibling ``dc_solver`` module (shared with
-``discovery.DiscoveryEngine``, Layer 3, which reuses the same solved
-potentials). This module owns the public scoring API:
-
-  - Semantic field    = electric potential V(entity) at every node
+Models the knowledge graph as a resistor network; the Laplacian/Dirichlet
+solve live in the sibling ``dc_solver`` module (shared with
+``discovery.DiscoveryEngine``, Layer 3).
 
 For a multi-constraint AND query (``compute_and``) each constraint specifies
 a relationship-type filter together with its anchor set.  Each constraint is

--- a/open_kgo/feature_groups/kg/ontology/tests/test_semantic_field.py
+++ b/open_kgo/feature_groups/kg/ontology/tests/test_semantic_field.py
@@ -29,8 +29,9 @@ from pathlib import Path
 
 import pytest
 
+from open_kgo.feature_groups.kg.ontology.dc_solver import conductance
 from open_kgo.feature_groups.kg.ontology.registry import OntologyRegistry
-from open_kgo.feature_groups.kg.ontology.semantic_field import SemanticField, _conductance
+from open_kgo.feature_groups.kg.ontology.semantic_field import SemanticField
 
 FIXTURE_DIR = Path(__file__).parent / "fixtures"
 METAQA_YAML = FIXTURE_DIR / "metaqa_ontology.yaml"
@@ -51,16 +52,16 @@ MOVIE_EDGES: list[tuple[str, str, str]] = [
 class TestConductance:
     def test_declared_weight_returned(self) -> None:
         OntologyRegistry.load_file(str(METAQA_YAML))
-        assert _conductance("movie", "directed_by") == pytest.approx(0.9)
-        assert _conductance("movie", "has_genre") == pytest.approx(0.7)
-        assert _conductance("movie", "has_tags") == pytest.approx(0.2)
+        assert conductance("movie", "directed_by") == pytest.approx(0.9)
+        assert conductance("movie", "has_genre") == pytest.approx(0.7)
+        assert conductance("movie", "has_tags") == pytest.approx(0.2)
 
     def test_unknown_relation_defaults_to_one(self) -> None:
         OntologyRegistry.load_file(str(METAQA_YAML))
-        assert _conductance("movie", "nonexistent_rel") == pytest.approx(1.0)
+        assert conductance("movie", "nonexistent_rel") == pytest.approx(1.0)
 
     def test_no_ontology_defaults_to_one(self) -> None:
-        assert _conductance("movie", "directed_by") == pytest.approx(1.0)
+        assert conductance("movie", "directed_by") == pytest.approx(1.0)
 
 
 class TestComputeSingleAnchor:

--- a/open_kgo/feature_groups/kg/reader_base.py
+++ b/open_kgo/feature_groups/kg/reader_base.py
@@ -79,6 +79,10 @@ from mloda.provider import HashableDict
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
 from open_kgo.feature_groups.kg import class_guards, composition, credentials as credential_rules
+from open_kgo.feature_groups.kg.composition import (  # noqa: F401 -- back-compat re-export, moved to composition.py
+    compose_property_mapping,
+    narrow_property_mapping,
+)
 from open_kgo.feature_groups.kg.errors import InvalidCredentialShape
 from open_kgo.feature_groups.kg.spec import property_spec
 

--- a/open_kgo/feature_groups/kg/reader_base.py
+++ b/open_kgo/feature_groups/kg/reader_base.py
@@ -6,17 +6,19 @@ The split mirrors mloda core's ``ReadDB`` + ``ReadDBFeature`` pattern (see
 extends ``KgConnectorReaderBase`` (which extends ``ReadDB``) and a
 ``<Family>FeatureGroup`` that extends ``KgConnectorFeatureGroupBase``.
 
-Module layout: this module owns ``LoadContext``, the property-mapping
-composition helpers, and ``KgConnectorReaderBase``; the two per-call reader
-flavors (``QueryReader`` / ``ParamReader``) live in ``kg.readers`` and the
-FeatureGroup base in ``kg.feature_group``. All of it is re-exported through
-``kg.base``, the documented front door, so references elsewhere to
-"base.py" resolve here via one hop. The validation bodies live in two
-concern modules and the base keeps thin delegating classmethods: runtime
-credential validation (slot extraction, shape and enum checks, env
-resolution) in ``kg.credentials``, and the class-definition-time guards
-(mapping shapes, ``SUPPORTED_VALUES`` invariants, waiver hygiene, the
-source-slot convention) in ``kg.class_guards``.
+Module layout: this module owns ``LoadContext`` and ``KgConnectorReaderBase``;
+the two per-call reader flavors (``QueryReader`` / ``ParamReader``) live in
+``kg.readers`` and the FeatureGroup base in ``kg.feature_group``. All of it is
+re-exported through ``kg.base``, the documented front door, so references
+elsewhere to "base.py" resolve here via one hop. The validation and
+composition bodies live in three concern modules and the base keeps thin
+delegating classmethods: runtime credential validation (slot extraction,
+shape and enum checks, env resolution) in ``kg.credentials``, the
+class-definition-time guards (mapping shapes, ``SUPPORTED_VALUES``
+invariants, waiver hygiene, the source-slot convention) in
+``kg.class_guards``, and the property-mapping composition helpers
+(``compose_property_mapping`` / ``narrow_property_mapping`` /
+``_compose_family_surface``) in ``kg.composition``.
 
 Concrete plugins set ``CONNECTOR_ID`` and implement ``connect``,
 ``build_query``, ``load_data``. mloda's ``BaseInputData.match_data_access``
@@ -76,12 +78,8 @@ from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.provider import HashableDict
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
-from open_kgo.feature_groups.kg import class_guards, credentials as credential_rules
-from open_kgo.feature_groups.kg.errors import (
-    InvalidCredentialShape,
-    NonDictSpecError,
-    PropertyMappingCollision,
-)
+from open_kgo.feature_groups.kg import class_guards, composition, credentials as credential_rules
+from open_kgo.feature_groups.kg.errors import InvalidCredentialShape
 from open_kgo.feature_groups.kg.spec import property_spec
 
 
@@ -106,51 +104,6 @@ class LoadContext:
     slot: Mapping[str, Any]
     result_limit: int
     ontology_namespace: str | None = None
-
-
-def compose_property_mapping(*sources: dict[str, Any], context: str = "") -> dict[str, Any]:
-    """Merge property-mapping dicts and raise on duplicate keys.
-
-    Replaces the spread-merge ``{**A, **B, **C}`` idiom used by family bases.
-    The spread-merge silently overwrites duplicates; this helper raises
-    ``PropertyMappingCollision`` so structural collisions surface at import
-    time. ``context`` is the family/mixin name carried into the error message.
-
-    Also rejects non-dict spec values at composition time via
-    ``NonDictSpecError``. A ``None`` spec would otherwise pass downstream
-    ``mapping.get(key) is None`` lookups and surface as a self-contradicting
-    "unknown credential key" error: the key is listed in ``allowed`` but
-    ``_validate_mapping`` cannot distinguish a missing key from a ``None``
-    spec via ``.get``. Catching it here keeps the closed-world check honest.
-    ``NonDictSpecError`` is a sibling of ``PropertyMappingCollision`` under
-    ``InvalidCredentialShape`` so callers can scope a single typed handler
-    across the whole structural-error family.
-    """
-    merged: dict[str, Any] = {}
-    for source in sources:
-        for key, spec in source.items():
-            if key in merged:
-                raise PropertyMappingCollision(key, context=context)
-            if not isinstance(spec, dict):
-                raise NonDictSpecError(key, spec, context=context)
-            merged[key] = spec
-    return merged
-
-
-def narrow_property_mapping(source: dict[str, Any], *exclude: str) -> dict[str, Any]:
-    """Return ``source`` minus the ``exclude`` keys — the narrowing companion to ``compose_property_mapping``.
-
-    Concrete plugins drop family-level keys they do not honor (advertising
-    a key the reader ignores would be a surface lie that the closed-world
-    credential check then rejects). This is option 1 of the "Honest credential
-    surface" rule in this module's docstring. Several concretes spelled this as an
-    inline ``{k: v for k, v in Parent.PROPERTY_MAPPING.items() if k not in {...}}``
-    comprehension; centralising it names the intent and keeps the narrowing
-    rule in one place. Keys in ``exclude`` that are absent from ``source``
-    are silently ignored (narrowing is idempotent).
-    """
-    excluded = set(exclude)
-    return {k: v for k, v in source.items() if k not in excluded}
 
 
 # History: the universal property mapping previously declared
@@ -320,80 +273,8 @@ class KgConnectorReaderBase(ReadDB):
 
     @classmethod
     def _compose_family_surface(cls, family_properties: dict[str, Any], family_params: dict[str, Any]) -> None:
-        """Auto-compose ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` for a family base.
-
-        Family bases used to spell the same ritual: ``PROPERTY_MAPPING =
-        compose_property_mapping(Parent.PROPERTY_MAPPING, Mixin.PROPERTY_
-        MAPPING_DELTA, {family keys}, context=...)`` and a parallel call for
-        ``PARAMS_MAPPING``, which made it possible to inherit a mixin yet
-        forget to merge one of its delta layers. Declaring the surface as
-        class keyword arguments instead::
-
-            class CitationRestReader(PaginationMixin, ParamReader,
-                                     family_properties={...},
-                                     family_params={...}):
-
-        routes through here: the inherited mapping (the parent reader's),
-        every ``PROPERTY_MAPPING_DELTA`` / ``PARAMS_MAPPING_DELTA`` found in
-        the MRO (the declared mixins), and the family keys are composed with
-        ``compose_property_mapping`` (duplicate keys raise, as before) before
-        the class-definition guards run.
-
-        Rules:
-        - Opt-in: only classes passing ``family_properties`` and/or
-          ``family_params`` are touched; concrete plugins keep assembling
-          their narrowed mappings explicitly in the class body.
-        - Mixing styles is rejected: a class that opts in must not also
-          assign either mapping in its body (the body value would silently
-          win over the parent/mixin layers).
-        - ``PARAMS_MAPPING`` is composed only for readers that have the
-          attribute (``ParamReader`` descendants). A ``QueryReader`` family
-          may inherit a mixin with a params delta (agent_memory inherits
-          ``PaginationMixin``); the delta is deliberately ignored because the
-          flavor has no ``build_params`` to honor it, and passing
-          ``family_params`` on such a family raises.
-        - Deltas are collected from the WHOLE MRO. A future family base that
-          subclasses another family base which already absorbed a mixin would
-          re-collect that mixin's delta and fail loudly with a
-          ``PropertyMappingCollision`` at import; such a chain needs explicit
-          composition instead of this opt-in.
-        """
-        for layer in ("PROPERTY_MAPPING", "PARAMS_MAPPING"):
-            if layer in cls.__dict__:
-                raise ValueError(
-                    f"{cls.__name__} passes family_properties/family_params but also assigns {layer} "
-                    f"in its class body; declare the surface one way only."
-                )
-        property_deltas = [
-            klass.__dict__["PROPERTY_MAPPING_DELTA"]
-            for klass in cls.__mro__
-            if "PROPERTY_MAPPING_DELTA" in klass.__dict__
-        ]
-        cls.PROPERTY_MAPPING = compose_property_mapping(
-            cls.PROPERTY_MAPPING, *property_deltas, family_properties, context=cls.__name__
-        )
-        params_mapping = getattr(cls, "PARAMS_MAPPING", None)
-        if params_mapping is None:
-            if family_params:
-                raise ValueError(
-                    f"{cls.__name__} passes family_params but is not a ParamReader descendant; "
-                    f"query-flavored families have no PARAMS_MAPPING layer."
-                )
-            return
-        params_deltas = [
-            klass.__dict__["PARAMS_MAPPING_DELTA"] for klass in cls.__mro__ if "PARAMS_MAPPING_DELTA" in klass.__dict__
-        ]
-        if params_deltas or family_params:
-            # setattr because PARAMS_MAPPING is declared on ParamReader, not on
-            # this universal base; the getattr gate above already proved cls is
-            # a params-flavored reader.
-            setattr(  # noqa: B010
-                cls,
-                "PARAMS_MAPPING",
-                compose_property_mapping(
-                    params_mapping, *params_deltas, family_params, context=f"{cls.__name__}.PARAMS_MAPPING"
-                ),
-            )
+        """Auto-compose ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` for a family base; see ``composition.compose_family_surface``."""
+        composition.compose_family_surface(cls, family_properties, family_params)
 
     @classmethod
     def _validate_mapping_spec_shapes(cls) -> None:

--- a/open_kgo/feature_groups/kg/reader_base.py
+++ b/open_kgo/feature_groups/kg/reader_base.py
@@ -9,16 +9,9 @@ extends ``KgConnectorReaderBase`` (which extends ``ReadDB``) and a
 Module layout: this module owns ``LoadContext`` and ``KgConnectorReaderBase``;
 the two per-call reader flavors (``QueryReader`` / ``ParamReader``) live in
 ``kg.readers`` and the FeatureGroup base in ``kg.feature_group``. All of it is
-re-exported through ``kg.base``, the documented front door, so references
-elsewhere to "base.py" resolve here via one hop. The validation and
-composition bodies live in three concern modules and the base keeps thin
-delegating classmethods: runtime credential validation (slot extraction,
-shape and enum checks, env resolution) in ``kg.credentials``, the
-class-definition-time guards (mapping shapes, ``SUPPORTED_VALUES``
-invariants, waiver hygiene, the source-slot convention) in
-``kg.class_guards``, and the property-mapping composition helpers
-(``compose_property_mapping`` / ``narrow_property_mapping`` /
-``_compose_family_surface``) in ``kg.composition``.
+re-exported through ``kg.base``, the documented front door. Validation and
+composition bodies live in ``kg.credentials``, ``kg.class_guards``, and
+``kg.composition``; the base keeps thin delegating classmethods.
 
 Concrete plugins set ``CONNECTOR_ID`` and implement ``connect``,
 ``build_query``, ``load_data``. mloda's ``BaseInputData.match_data_access``


### PR DESCRIPTION
## Summary

Three behavior-preserving move/split refactors, found by surveying the codebase for the highest-value, lowest-risk structural cleanups still available (this repo's `kg/` package is already unusually well-factored, so genuine dead code / duplication was scarce):

- **`reader_base.py` -> `composition.py`**: extracted `compose_property_mapping`, `narrow_property_mapping`, and the body of `_compose_family_surface` into a new concern module, mirroring the existing `class_guards.py`/`credentials.py` split that `reader_base.py`'s own docstring already describes. `reader_base.py` drops from 798 to ~680 lines.
- **`ontology/semantic_field.py` -> `ontology/dc_solver.py`**: extracted the shared DC-circuit Laplacian/Dirichlet solver internals. This was motivated by finding that `ontology/discovery.py` (DiscoveryEngine, Layer 3) was already importing `_compute_field`/`_conductance` directly out of `semantic_field.py`'s underscore-prefixed "private" names, reaching across a module boundary. `discovery.py` now imports the same primitives from the new shared `dc_solver.py` module instead.
- **`ontology/registry.py` -> `ontology/models.py`**: moved the `RelationshipRule`/`NamespaceOntology` dataclasses and YAML parser out, leaving `OntologyRegistry` as a pure cache/lookup class.

A dual review pass (fresh Claude Opus + `codex review`) caught two backward-compatibility gaps in the initial split (this is a published PyPI package, so old import paths matter): `compose_property_mapping`/`narrow_property_mapping` were no longer bound on `reader_base`, and `RelationshipRule` was no longer importable from `registry`. Both are re-exported from their new homes now. Also tightened `dc_solver.py`'s public surface per an Opus nit: `build_laplacian`/`solve_dirichlet` are internal-only (nothing outside `dc_solver.py` calls them), so they're back to `_`-prefixed.

## Test plan

- [x] `tox` (pytest, ruff format --check, ruff check, mypy --strict, bandit) passes clean: 1037 passed, 57 skipped
- [x] Verified no stale references to moved/renamed symbols anywhere in the repo (grepped production code, tests, demos)
- [x] Verified `kg.base` and `kg.ontology` re-exports still resolve at runtime