### PR TITLE
chore(deps): bump mloda to 0.10.0

### DIFF
--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -1,23 +1,15 @@
 """Thin KG wrapper over mloda core's ``property_spec`` PROPERTY_MAPPING builder.
 
-Core ships ``mloda.provider.property_spec`` plus the first-class
-``DefaultOptionKeys.allowed_values`` field (since 0.9.0), so open-kgo no longer
-maintains its own copy of the builder/validation (see mloda-ai/open-kgo#29).
-The floor is 0.10.0 because core renamed ``RESERVED_PROPERTY_KEYS`` to
-``PROPERTY_SPEC_KEYS`` with no alias and relaxed the non-strict
-``allowed_values`` rule this wrapper still enforces.
-
-Core validates the spec's invariants; this wrapper preserves two open-kgo
-conventions core does not:
+Core owns the builder and its invariants (see mloda-ai/open-kgo#29); this wrapper
+adds two open-kgo conventions:
 
 - ``default`` is always emitted (explicit ``None`` when unset) so KG specs read
-  uniformly via subscript across the validation/discovery/contract layer. The
-  extra key is in core's ``PROPERTY_SPEC_KEYS`` and so is ignored by core's own
-  spec parser.
+  uniformly via subscript. The key is in core's ``PROPERTY_SPEC_KEYS``, so core's
+  own parser ignores it.
 - ``allowed_values`` requires ``strict=True``. Core permits a non-strict value
-  space because it still maps a name-parsed value back onto its key; KG specs
-  are never name-parsed, and ``_validate_mapping`` enforces the allowed set only
-  under ``strict_validation``, so a non-strict enum here would be decorative.
+  space (it still maps a name-parsed value back onto its key), but KG specs are
+  never name-parsed and ``_validate_mapping`` enforces the set only under
+  ``strict_validation``, so a non-strict enum here would be decorative.
 """
 
 from __future__ import annotations
@@ -41,8 +33,7 @@ def property_spec(
     if allowed_values is not None and not strict:
         raise ValueError(
             f"property_spec({explanation!r}): allowed_values is never enforced without strict=True. "
-            f"KG specs validate credentials, not feature names, so a non-strict value space is "
-            f"decorative. Pass strict=True, or drop allowed_values."
+            f"Pass strict=True, or drop allowed_values."
         )
     spec = _core_property_spec(
         explanation,

--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -1,13 +1,19 @@
 """Thin KG wrapper over mloda core's ``property_spec`` PROPERTY_MAPPING builder.
 
-mloda>=0.9.0 ships ``mloda.provider.property_spec`` plus the first-class
+mloda>=0.10.0 ships ``mloda.provider.property_spec`` plus the first-class
 ``DefaultOptionKeys.allowed_values`` field, so open-kgo no longer maintains its
 own copy of the builder/validation (see mloda-ai/open-kgo#29). Core validates
-the spec's invariants; this wrapper only preserves one open-kgo convention core
-does not: ``default`` is always emitted (explicit ``None`` when unset) so KG
-specs read uniformly via subscript across the validation/discovery/contract
-layer. The extra key is in core's ``RESERVED_PROPERTY_KEYS`` and so is ignored
-by core's own spec parser.
+the spec's invariants; this wrapper preserves two open-kgo conventions core
+does not:
+
+- ``default`` is always emitted (explicit ``None`` when unset) so KG specs read
+  uniformly via subscript across the validation/discovery/contract layer. The
+  extra key is in core's ``PROPERTY_SPEC_KEYS`` and so is ignored by core's own
+  spec parser.
+- ``allowed_values`` requires ``strict=True``. Core permits a non-strict value
+  space because it still maps a name-parsed value back onto its key; KG specs
+  are never name-parsed, and ``_validate_mapping`` enforces the allowed set only
+  under ``strict_validation``, so a non-strict enum here would be decorative.
 """
 
 from __future__ import annotations
@@ -28,6 +34,12 @@ def property_spec(
     context: bool = True,
 ) -> dict[str, Any]:
     """Build a PROPERTY_MAPPING spec dict via core, keeping ``default`` always present."""
+    if allowed_values is not None and not strict:
+        raise ValueError(
+            f"property_spec({explanation!r}): allowed_values is never enforced without strict=True. "
+            f"KG specs validate credentials, not feature names, so a non-strict value space is "
+            f"decorative. Pass strict=True, or drop allowed_values."
+        )
     spec = _core_property_spec(
         explanation,
         strict=strict,

--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -1,10 +1,14 @@
 """Thin KG wrapper over mloda core's ``property_spec`` PROPERTY_MAPPING builder.
 
-mloda>=0.10.0 ships ``mloda.provider.property_spec`` plus the first-class
-``DefaultOptionKeys.allowed_values`` field, so open-kgo no longer maintains its
-own copy of the builder/validation (see mloda-ai/open-kgo#29). Core validates
-the spec's invariants; this wrapper preserves two open-kgo conventions core
-does not:
+Core ships ``mloda.provider.property_spec`` plus the first-class
+``DefaultOptionKeys.allowed_values`` field (since 0.9.0), so open-kgo no longer
+maintains its own copy of the builder/validation (see mloda-ai/open-kgo#29).
+The floor is 0.10.0 because core renamed ``RESERVED_PROPERTY_KEYS`` to
+``PROPERTY_SPEC_KEYS`` with no alias and relaxed the non-strict
+``allowed_values`` rule this wrapper still enforces.
+
+Core validates the spec's invariants; this wrapper preserves two open-kgo
+conventions core does not:
 
 - ``default`` is always emitted (explicit ``None`` when unset) so KG specs read
   uniformly via subscript across the validation/discovery/contract layer. The

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -51,12 +51,7 @@ class TestPropertySpecInvariants:
             property_spec("Strict but empty.", strict=True, allowed_values={})
 
     def test_allowed_values_without_strict_rejected(self) -> None:
-        """Wrapper-owned rule: core permits a non-strict value space, KG specs do not.
-
-        Core keeps it for feature-name parsing (a parsed value maps back onto its
-        key). KG specs are never name-parsed and ``_validate_mapping`` enforces the
-        allowed set only under ``strict_validation``, so it would be decorative.
-        """
+        """Wrapper-owned rule: core permits the shape, KG does not (see ``kg/spec.py``)."""
         with pytest.raises(ValueError, match="never enforced"):
             property_spec("Decorative enum.", allowed_values={"a": "Doc."})
 

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -65,7 +65,7 @@ class TestPropertySpecInvariants:
         ] == {"a": "Doc."}
 
     def test_strict_default_outside_allowed_set_rejected(self) -> None:
-        with pytest.raises(ValueError, match="not one of the accepted values"):
+        with pytest.raises(ValueError, match="declares default"):
             property_spec("Bad default.", strict=True, allowed_values={"a": "Doc."}, default="z")
 
     def test_strict_none_default_permitted(self) -> None:
@@ -77,7 +77,7 @@ class TestPropertySpecInvariants:
         """Plain iterables mirror ``spec_allowed_values``; the default check still applies."""
         emitted = property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="b")
         assert emitted["allowed_values"] == ("a", "b")
-        with pytest.raises(ValueError, match="not one of the accepted values"):
+        with pytest.raises(ValueError, match="declares default"):
             property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="z")
 
     def test_generator_allowed_values_materialized(self) -> None:

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -1,9 +1,9 @@
 """Tests for the KG ``property_spec`` wrapper (``kg/spec.py``).
 
 The wrapper delegates construction and invariant validation to mloda core
-(``mloda.provider.property_spec``); these tests pin the one open-kgo-specific
-behavior it adds (``default`` always emitted) and confirm core's validation is
-in force through the wrapper.
+(``mloda.provider.property_spec``); these tests pin the two open-kgo-specific
+behaviors it adds (``default`` always emitted, ``allowed_values`` requires
+strict) and confirm core's validation is in force through the wrapper.
 """
 
 from __future__ import annotations
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import property_spec as _core_property_spec
 
 from open_kgo.feature_groups.kg.spec import property_spec
 
@@ -50,11 +51,21 @@ class TestPropertySpecInvariants:
             property_spec("Strict but empty.", strict=True, allowed_values={})
 
     def test_allowed_values_without_strict_rejected(self) -> None:
+        """Wrapper-owned rule: core permits a non-strict value space, KG specs do not.
+
+        Core keeps it for feature-name parsing (a parsed value maps back onto its
+        key). KG specs are never name-parsed and ``_validate_mapping`` enforces the
+        allowed set only under ``strict_validation``, so it would be decorative.
+        """
         with pytest.raises(ValueError, match="never enforced"):
             property_spec("Decorative enum.", allowed_values={"a": "Doc."})
 
+        assert _core_property_spec("Decorative enum.", allowed_values={"a": "Doc."})[
+            DefaultOptionKeys.allowed_values
+        ] == {"a": "Doc."}
+
     def test_strict_default_outside_allowed_set_rejected(self) -> None:
-        with pytest.raises(ValueError, match="not in the accepted set"):
+        with pytest.raises(ValueError, match="not one of the accepted values"):
             property_spec("Bad default.", strict=True, allowed_values={"a": "Doc."}, default="z")
 
     def test_strict_none_default_permitted(self) -> None:
@@ -66,7 +77,7 @@ class TestPropertySpecInvariants:
         """Plain iterables mirror ``spec_allowed_values``; the default check still applies."""
         emitted = property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="b")
         assert emitted["allowed_values"] == ("a", "b")
-        with pytest.raises(ValueError, match="not in the accepted set"):
+        with pytest.raises(ValueError, match="not one of the accepted values"):
             property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="z")
 
     def test_generator_allowed_values_materialized(self) -> None:

--- a/open_kgo/feature_groups/kg/tests/test_validation_contract.py
+++ b/open_kgo/feature_groups/kg/tests/test_validation_contract.py
@@ -99,21 +99,16 @@ def test_strict_specs_declare_allowed_values_explicitly() -> None:
 
 
 def test_nonstrict_specs_declare_no_allowed_values() -> None:
-    """The converse: a non-strict spec must not carry ``allowed_values``.
+    """The converse: a non-strict value space is never enforced, so it must not exist.
 
-    ``_validate_mapping`` only enforces an allowed set under
-    ``strict_validation``, so a non-strict value space is decorative and would
-    read as a constraint that nothing applies. ``kg/spec.py`` rejects it at
-    construction, but specs are also hand-assembled (dict-spread, comprehension
-    narrowing), and mloda core permits the shape since 0.10.0. This walk covers
-    the builder-bypassing paths.
+    ``kg/spec.py`` rejects it at construction, but specs are also hand-assembled
+    (dict-spread, comprehension narrowing) and core permits the shape.
     """
     for klass in walk_subclasses(KgConnectorReaderBase):
         for key, spec, layer_name in iter_nonstrict_specs(klass):
             assert "allowed_values" not in spec, (
                 f"{klass.__name__}.{layer_name}[{key!r}] declares 'allowed_values' without "
-                f"strict_validation=True, so the set is never enforced. Set strict_validation=True, "
-                f"or drop 'allowed_values'."
+                f"strict_validation=True, so the set is never enforced."
             )
 
 

--- a/open_kgo/feature_groups/kg/tests/test_validation_contract.py
+++ b/open_kgo/feature_groups/kg/tests/test_validation_contract.py
@@ -33,6 +33,7 @@ from open_kgo.feature_groups.kg.errors import (
 from open_kgo.feature_groups.kg.lineage.dbt_manifest import DbtManifestReader
 from open_kgo.feature_groups.kg.tests._discovery import (
     import_all_kg_readers,
+    iter_nonstrict_specs,
     iter_strict_specs,
     walk_subclasses,
 )
@@ -94,6 +95,25 @@ def test_strict_specs_declare_allowed_values_explicitly() -> None:
         for key, spec, layer_name in iter_strict_specs(klass):
             assert "allowed_values" in spec, (
                 f"{klass.__name__}.{layer_name}[{key!r}] has strict_validation=True but no 'allowed_values' field."
+            )
+
+
+def test_nonstrict_specs_declare_no_allowed_values() -> None:
+    """The converse: a non-strict spec must not carry ``allowed_values``.
+
+    ``_validate_mapping`` only enforces an allowed set under
+    ``strict_validation``, so a non-strict value space is decorative and would
+    read as a constraint that nothing applies. ``kg/spec.py`` rejects it at
+    construction, but specs are also hand-assembled (dict-spread, comprehension
+    narrowing), and mloda core permits the shape since 0.10.0. This walk covers
+    the builder-bypassing paths.
+    """
+    for klass in walk_subclasses(KgConnectorReaderBase):
+        for key, spec, layer_name in iter_nonstrict_specs(klass):
+            assert "allowed_values" not in spec, (
+                f"{klass.__name__}.{layer_name}[{key!r}] declares 'allowed_values' without "
+                f"strict_validation=True, so the set is never enforced. Set strict_validation=True, "
+                f"or drop 'allowed_values'."
             )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,9 @@ Repository = "https://github.com/mloda-ai/open-kgo"
 Issues = "https://github.com/mloda-ai/open-kgo/issues"
 
 [project.optional-dependencies]
-# mloda-testing backs the in-repo contract harness (open_kgo/**/tests/), which
-# is excluded from the wheel, so it is a dev-only dependency.
+# The KG contract harness (open_kgo/**/tests/) is in-repo and imports nothing
+# from mloda-testing; only tests/test_mloda_imports.py does, as an import smoke
+# test. Dev-only either way: the test trees are excluded from the wheel.
 dev = [
     "tox",
     "tox-uv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,8 @@ Repository = "https://github.com/mloda-ai/open-kgo"
 Issues = "https://github.com/mloda-ai/open-kgo/issues"
 
 [project.optional-dependencies]
-# The KG contract harness (open_kgo/**/tests/) is in-repo and imports nothing
-# from mloda-testing; only tests/test_mloda_imports.py does, as an import smoke
-# test. Dev-only either way: the test trees are excluded from the wheel.
+# mloda-testing is exercised only by tests/test_mloda_imports.py (import smoke);
+# the KG contract harness is in-repo. Dev-only: test trees are out of the wheel.
 dev = [
     "tox",
     "tox-uv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "open-kgo"
 # semantic-release bumps the latest git tag; needs a `0.2.0` tag pushed once by
-# hand to bootstrap. The mloda floor (>=0.9.0) is unrelated.
+# hand to bootstrap. The mloda floor (>=0.10.0) is unrelated.
 version = "0.3.0"
 description = "Open Knowledge Graphs and Ontologies plugin for mloda."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "tomkaltofen@mloda.ai" }]
-dependencies = ["mloda>=0.9.0"]
+dependencies = ["mloda>=0.10.0"]
 requires-python = ">=3.10"
 # No `License ::` trove classifier: `license` above is an SPDX expression
 # (PEP 639) and setuptools rejects both together.
@@ -45,7 +45,7 @@ dev = [
     "ruff",
     "mypy",
     "bandit",
-    "mloda-testing>=0.3.1",
+    "mloda-testing>=0.3.2",
 ]
 kg-rdf = ["rdflib>=7.0", "pyoxigraph>=0.5.9"]
 kg-embedded = ["networkx>=3.2", "igraph>=0.11"]

--- a/uv.lock
+++ b/uv.lock
@@ -99,7 +99,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -220,7 +220,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -646,10 +646,10 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.9.0"
+version = "0.10.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/82/a7893ddd9ab26dd839671c594e9c16437364a8b8ed5dffb02e9b2de52d7f/mloda-0.9.0-py3-none-any.whl", hash = "sha256:d193b03622e6c8670ccde500c9e6d74eba9ef4ed70ca3bd6adbcb9330a370585", size = 430826, upload-time = "2026-07-07T08:48:32.032Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/9d/2251f947bfde5e168b9f6759079c8b54af0393c3e854987268459b860776/mloda-0.10.0-py3-none-any.whl", hash = "sha256:13fd1482566de203cac661c29f5736423ce7d1cc8e43ec26f8d24d19e6386229", size = 456550, upload-time = "2026-07-13T18:35:02.322Z" },
 ]
 
 [[package]]
@@ -895,8 +895,8 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'kg-embedded'", specifier = ">=0.11" },
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
-    { name = "mloda", specifier = ">=0.9.0" },
-    { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.1" },
+    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },
     { name = "networkx", marker = "extra == 'kg-memory'", specifier = ">=3.2" },
@@ -1190,7 +1190,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
Raises the mloda floor to `>=0.10.0` (and `mloda-testing` to `>=0.3.2`), re-locks, and adapts to the one 0.10.0 breaking change that has surface in this repo.

## What 0.10.0 changed, and what it meant here

mloda 0.10.0 ships four breaking changes. Three have no surface in open-kgo, verified rather than assumed:

- **`validation_function` / `type_validator` removed**: no usage anywhere in `open_kgo/`, `demo/`, or `tests/`.
- **Bare-string input features now forward options like object children**: KG feature groups are leaf reader sources and declare no `input_features()`, so there is no forwarding surface.
- **FeatureSet name accessors return sorted tuples**: KG readers dispatch exactly one feature per load (`_assert_single_feature`), so name ordering cannot change which feature a reader picks.

The fourth one does bite. Core's `property_spec` now **permits `allowed_values` without `strict=True`**, where it previously rejected it. Core relaxed the rule because a non-strict value space still maps a name-parsed value back onto its PROPERTY_MAPPING key. KG specs are never name-parsed (there is no `FeatureChainParser` in this repo): they drive credential-shape validation, and `_validate_mapping` enforces an allowed set **only** under `strict_validation is True`. A non-strict enum here would therefore be decorative, silently unenforced. So the rejection stays, moved from core into the KG wrapper (`kg/spec.py`), which already exists to hold exactly this kind of local convention.

Because specs are also hand-assembled in places (dict-spread in `in_process_tuple_store`, comprehension narrowing in the rest/citation readers), the constructor guard alone does not cover every path. A cross-reader contract walk now asserts the invariant over all 235 non-strict specs.

Core also reworded its strict-default rejection message; the invariant is unchanged, so only the test regexes moved (to a fragment less likely to drift on the next reword).

## Notes for review

- `uv.lock` carries some unrelated churn beyond the two version bumps: marker rewrites on `cffi`, `exceptiongroup`, and `pyzmq` from a newer uv resolver. Harmless, nothing to read into it.
- The `mloda >= 0.9.0` mentions left in `reader_base.py` and `test_reader_load_wrap.py` are statements about when a capability was introduced. Still true under 0.10.0, so rewriting them to 0.10.0 would assert something false.
- The dev-extra comment claiming mloda-testing "backs the in-repo contract harness" was inaccurate (only `tests/test_mloda_imports.py` imports it); corrected while in the file.

## Verification

`tox` green: 1038 passed, 57 skipped, plus `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`. Reviewed independently by codex (no findings) and a second deep review whose findings are folded in.