### PR TITLE
docs: fix stale reference to kg-connector-base-classes doc

### DIFF
--- a/open_kgo/feature_groups/kg/README.md
+++ b/open_kgo/feature_groups/kg/README.md
@@ -1,7 +1,7 @@
 # KG connector base groups (prototype)
 
 Nine families derived from a 103-system survey (see
-`docs/kg-connector-base-classes.md` Version B). Each family is a
+Version B of the family map below). Each family is a
 `<Family>Reader(KgConnectorReaderBase)` + `<Family>FeatureGroup`, paired with
 **two** concrete plugins that run against in-memory libraries or local fixture
 files. No Docker, no external services. The second concrete per family is

--- a/open_kgo/feature_groups/kg/__init__.py
+++ b/open_kgo/feature_groups/kg/__init__.py
@@ -1,6 +1,6 @@
 """Knowledge-graph connector base groups (prototype).
 
-Validates the property layout from `docs/kg-connector-base-classes.md` Version B
+Validates the property layout from `open_kgo/feature_groups/kg/README.md` Version B
 against in-memory libraries and Python prototype implementations. No Docker, no
 external services. See `docs/kg-connector-config-examples.md` for credential
 shapes per family.

--- a/open_kgo/feature_groups/kg/rdf/__init__.py
+++ b/open_kgo/feature_groups/kg/rdf/__init__.py
@@ -1,7 +1,7 @@
 """RDF / SPARQL family of KG connectors.
 
 Family-base properties (beyond the universal layer) follow Version B of
-``docs/kg-connector-base-classes.md``: ``default_graph_uris``,
+``open_kgo/feature_groups/kg/README.md``: ``default_graph_uris``,
 ``named_graph_uris``, ``update_endpoint``, ``result_format``, plus
 ``reasoning_profile`` from ``InferenceMixin``.
 


### PR DESCRIPTION
Closes #43

Updates three instances of the stale reference `docs/kg-connector-base-classes.md` to point to the actual README file where the family map is located (`open_kgo/feature_groups/kg/README.md`).