### PR TITLE
chore(deps): bump pymdown-extensions to 11.0.1 via uv override

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,3 +108,9 @@ exclude-newer = "7 days"
 # releases immediately, accepting no quarantine window. Do NOT add third-party
 # packages here. Owner: tk.
 exclude-newer-package = { mloda = "0 days", "mloda-testing" = "0 days", "mloda-registry" = "0 days" }
+# Overrides, not constraints: marimo pins `pymdown-extensions<11`, and the fix for the
+# b64 path-traversal advisory only ships in 11.0. A constraint cannot beat that upper
+# pin, so the pin is overridden here. Drop this once marimo allows 11.x.
+override-dependencies = [
+    "pymdown-extensions>=11.0.1",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,9 @@ mloda-testing = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 mloda = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 mloda-registry = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
+[manifest]
+overrides = [{ name = "pymdown-extensions", specifier = ">=11.0.1" }]
+
 [[package]]
 name = "anyio"
 version = "4.13.0"
@@ -99,7 +102,7 @@ name = "cffi"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pycparser" },
+    { name = "pycparser", marker = "python_full_version < '3.15' and implementation_name != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
 wheels = [
@@ -220,7 +223,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1008,15 +1011,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]
@@ -1190,7 +1193,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "python_full_version < '3.15' and implementation_name == 'pypy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
Clears the one open Dependabot alert on this repo.

## What was blocking it

`pymdown-extensions` is transitive here (marimo). The b64 path-traversal advisory is fixed only in `11.0`, and there is no patched `10.x`. marimo declares `pymdown-extensions>=10.21.2,<11`, so `uv lock --upgrade-package pymdown-extensions` is a no-op: a constraint cannot beat an upper pin.

Note that the open grouped Dependabot PR #50 does **not** touch this package (it bumps mypy and grand-cypher), so it is not the fix despite being green.

## What this does

Adds `override-dependencies = ["pymdown-extensions>=11.0.1"]` to `[tool.uv]` and relocks. Resolves 10.21.3 -> 11.0.1.

The 11.0 break is `b64` restricting relative links to `base_path` by default (that is the fix) plus dropping Python 3.9, which is below this project's floor.

The lock diff also carries a few incidental marker refinements (cffi, exceptiongroup, pyzmq) from the relock. Remove the override once marimo allows 11.x.

## Verification

`tox`: 1038 passed, 57 skipped; ruff format, ruff check, mypy --strict and bandit all clean.