### PR TITLE
docs(workflows): sync the test-workflow docs with test.yml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:  # Allow manual triggering
 
 # Least-privilege token: these jobs only read the repo to run tests. Declared
-# explicitly (matching security-scan.yaml) so the workflow does not inherit a
-# wider default GITHUB_TOKEN scope if the repo/org default changes.
+# explicitly so the workflow does not inherit a wider default GITHUB_TOKEN
+# scope if the repo/org default changes.
 permissions:
   contents: read
 

--- a/docs/github-workflows.md
+++ b/docs/github-workflows.md
@@ -12,7 +12,17 @@ Dependency CVE scanning is left to GitHub's native Dependabot security alerts (e
 - Push to any branch
 - Pull request to `main`
 
-**Purpose:** Runs the full test suite using tox across multiple Python versions (3.10, 3.11, 3.12, 3.13). This includes pytest, ruff linting, mypy type checking, and bandit security analysis.
+**Jobs:** Two, each across the same Python matrix (3.10, 3.11, 3.12, 3.13, 3.14).
+
+- **`test`** runs `tox`, the default env: pytest (excluding the `notebooks`
+  marker), ruff formatting and linting, mypy type checking, and bandit security
+  analysis.
+- **`notebooks`** runs `tox -e notebooks`, which executes the demo marimo
+  notebooks end-to-end (`pytest -m notebooks`). That env additionally installs
+  the `demo` extra, which pulls in marimo. End-to-end execution is slow, so it
+  is kept out of the default `tox` run to keep local iteration and the main
+  matrix fast — but it is its own CI job, so the notebook suite still gates
+  pull requests.
 
 **Requirements:** None. This workflow uses only public GitHub Actions and requires no secrets.
 


### PR DESCRIPTION
Closes #53.

All three corrections from the issue, in one area:

**1. Python matrix.** `docs/github-workflows.md` listed 3.10–3.13; `test.yml` runs `["3.10", "3.11", "3.12", "3.13", "3.14"]` and `pyproject.toml` already carries the 3.14 classifier. Updated to 3.10–3.14.

**2. The `notebooks` job.** The doc described only the `test` job, so a contributor reading it would not know the marimo suite gates their PR. The `## Test Workflow` section now has a `**Jobs:**` list covering both:

- `test` runs the default `tox` env — `pytest -m "not notebooks"`, `ruff format --check`, `ruff check`, `mypy --strict`, `bandit`.
- `notebooks` runs `tox -e notebooks` → `pytest -m notebooks`, which additionally installs the `demo` extra (marimo). I noted why it is a separate env — slow end-to-end execution, kept out of the default run so local `tox` and the main matrix stay fast — and that it is nonetheless its own CI job, so it still gates pull requests.

**3. `security-scan.yaml`.** The `permissions:` comment at `.github/workflows/test.yml:11` explained itself as "matching security-scan.yaml". That workflow does not exist here — the repo has `test.yml` and `release.yaml`, and per the same doc, CVE scanning is deliberately Dependabot plus on-demand `tox -e security`. The comment now states the intent (least-privilege token, do not inherit a wider default) without naming a missing file. `grep -rn security-scan` over the tree now returns nothing.

## Verification

The change is Markdown and a YAML comment only. Nothing under `open_kgo/` or `tests/` reads these files (`grep -rn "github-workflows\|CONTRIBUTING\|ISSUE_TEMPLATE\|security-scan" tests/ open_kgo/ --include=*.py` is empty), and ruff/mypy/bandit only look at Python, so the `tox` gate is untouched by this diff. I did confirm `test.yml` still parses and still declares both jobs:

```
python -c "import yaml; print(list(yaml.safe_load(open('.github/workflows/test.yml'))['jobs']))"
['test', 'notebooks']
```
