### PR TITLE
docs(contributing): describe the single issue form that ships in this repo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,22 @@ It runs pytest, `ruff format --check`, `ruff check`, `mypy --strict`, and bandit
 
 ## Reporting issues
 
-Use the issue template (Bug report / Feature request). One-sentence summary,
-reproduction or motivation, code pointers (`file:line`), and a definition of
-done if scoped.
+There is a single **Issue** form — it covers bugs, feature requests, and small
+tasks alike. Blank issues are disabled, so that form is the only path.
+
+It asks for:
+
+- **Summary** — one sentence describing the bug, request, or task.
+- **Reproduction or motivation** — minimal steps plus expected vs. actual for
+  bugs; motivation, current workaround, and desired behavior for features and
+  tasks.
+- **Code pointers** (optional) — `file:line` references, so a newcomer can find
+  the starting point quickly.
+- **Definition of done** (optional) — what counts as complete: behavior, tests,
+  docs.
+- **Environment** (optional, bugs only) — Python version, OS, mloda version.
+
+For questions that are not issues, the New Issue page also links the
+[mloda documentation](https://mloda-ai.github.io/mloda/) and the
+[mloda framework](https://github.com/mloda-ai/mloda) repository, which is the
+place to start a broader conversation.


### PR DESCRIPTION
Closes #54.

`CONTRIBUTING.md` ended with "Use the issue template (Bug report / Feature request)", but this repo ships one unified `Issue` form and `config.yml` sets `blank_issues_enabled: false` — so a first-time contributor went looking for a choice the New Issue page does not offer.

The `## Reporting issues` section now:

- names the single **Issue** form and says blank issues are disabled, so it is the only path;
- lists the five fields the form actually asks for, keeping the useful guidance the old text carried (summary, reproduction or motivation, code pointers, definition of done) and adding the two the old text omitted — that the pointers/DoD/environment fields are optional, and that Environment is bugs-only;
- points at the two `config.yml` contact links (mloda documentation, mloda framework) for questions that are not issues.

Field list checked line-by-line against `.github/ISSUE_TEMPLATE/issue.yml`: `summary`, `details`, `pointers`, `dod`, `environment`, with `required: true` on the first two only.

## Verification

Markdown only. Nothing under `open_kgo/` or `tests/` reads `CONTRIBUTING.md`, and ruff/mypy/bandit only inspect Python, so the `tox` gate is unaffected by this diff.
