### PR TITLE
docs(issue-template): replace the two inherited placeholder examples

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue.yml
+++ b/.github/ISSUE_TEMPLATE/issue.yml
@@ -6,7 +6,7 @@ body:
     attributes:
       label: Summary
       description: One-sentence description of the bug, request, or task.
-      placeholder: e.g. "Placeholder rename steps break when the directory contains spaces."
+      placeholder: e.g. "The rdf connector drops the graph prefix when a SPARQL result column is unbound."
     validations:
       required: true
   - type: textarea
@@ -44,5 +44,5 @@ body:
     id: environment
     attributes:
       label: Environment (optional, bugs only)
-      description: Python version, OS, mloda version.
-      placeholder: Python 3.12, Linux, mloda 0.6.1
+      description: Python version, OS, mloda version, open-kgo version.
+      placeholder: Python 3.12, Linux, mloda 0.10.0, open-kgo 0.3.1


### PR DESCRIPTION
Closes #55.

Both inherited placeholders in `.github/ISSUE_TEMPLATE/issue.yml` are replaced.

**Summary field.** Was `e.g. "Placeholder rename steps break when the directory contains spaces."` — that describes `bin/customize.sh` in `mloda-plugin-template`, which has no counterpart here. Now:

> `e.g. "The rdf connector drops the graph prefix when a SPARQL result column is unbound."`

drawn from this repo's own `open_kgo/feature_groups/kg/rdf/` family, so it matches the `Code pointers` example that was already adapted.

**Environment field.** Was `Python 3.12, Linux, mloda 0.6.1`, below the `dependencies = ["mloda>=0.10.0"]` floor in `pyproject.toml` — it suggested a version the package will not install with. Now `Python 3.12, Linux, mloda 0.10.0, open-kgo 0.3.1`: Python 3.12 is inside the tested 3.10–3.14 range, the mloda version is at the declared floor, and it adds the open-kgo version.

While there, per step 3 I skimmed the other field wording. One more thing had drifted: the Environment field's `description` asked only for "Python version, OS, mloda version", so the plugin's own version — the first thing you need to triage an open-kgo bug — was never requested. That now reads "Python version, OS, mloda version, open-kgo version", matching the placeholder. The remaining descriptions and the `details`/`dod` placeholders are generic and carry no template-specific wording.

## Verification

```
python -c "import yaml; print([b['id'] for b in yaml.safe_load(open('.github/ISSUE_TEMPLATE/issue.yml'))['body']])"
['summary', 'details', 'pointers', 'dod', 'environment']
```

YAML-only. Nothing under `open_kgo/` or `tests/` reads the issue template, and ruff/mypy/bandit only inspect Python, so the `tox` gate is unaffected by this diff.
