### PR TITLE
test: execute the README Quickstart and assert it returns rows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,11 @@ dev = [
     "tox-uv",
     "uv>=0.11.6",
     "pytest",
-    "ruff",
+    # Pinned exactly: tox's default env resolves dependencies independently of
+    # uv.lock (see mloda-ai/open-kgo#66), so an unpinned ruff can silently drift
+    # to a release with different default rules/formatting than what was
+    # actually tested here, turning CI red for reasons unrelated to any change.
+    "ruff==0.15.20",
     "mypy",
     "bandit",
     "mloda-testing>=0.3.2",

--- a/tests/test_readme_quickstart.py
+++ b/tests/test_readme_quickstart.py
@@ -1,0 +1,119 @@
+"""Executes the README Quickstart snippet, the first code a new user runs.
+
+The demo notebooks are guarded end to end by test_demo_notebooks.py and the sample graph by
+test_demo_data.py, but nothing ran the Quickstart, so a renamed reader, a changed option key, or a
+new ``mloda.run_all`` signature could rot the one snippet every reader tries first.
+
+The block is located rather than copied: a duplicate here would drift from README.md silently, which
+is the failure this guards against. Locating it means a README restructure has to fail loudly instead
+of skipping the test, hence the explicit errors in _quickstart_snippet.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README = REPO_ROOT / "README.md"
+
+QUICKSTART_HEADING = "## Quickstart"
+
+# A markdown heading, only ever tested outside a fence: the snippet's own '# Point at any RDF file.'
+# comments match this too, so fence state has to be tracked rather than pattern-matched around.
+HEADING_PATTERN = re.compile(r"^#{1,6} ")
+FENCE_PATTERN = re.compile(r"^```(?P<language>\w*)")
+
+
+def _quickstart_snippet() -> str:
+    """Return the Quickstart's python block, raising rather than skipping if it moved.
+
+    Scans line by line: the next heading outside a fence ends the section, so a python block further
+    down the page can never stand in for a deleted one.
+    """
+    lines = README.read_text(encoding="utf-8").splitlines()
+
+    try:
+        start = next(index for index, line in enumerate(lines) if line.strip() == QUICKSTART_HEADING)
+    except StopIteration:
+        raise AssertionError(
+            f"{README.name} has no '{QUICKSTART_HEADING}' heading; this guard checks nothing."
+        ) from None
+
+    body: list[str] = []
+    inside_python = False
+
+    for line in lines[start + 1 :]:
+        fence = FENCE_PATTERN.match(line)
+        if fence is not None:
+            if inside_python:
+                break
+            inside_python = fence.group("language") == "python"
+            continue
+        if inside_python:
+            body.append(line)
+            continue
+        if HEADING_PATTERN.match(line):
+            # Left the Quickstart section without finding the block.
+            break
+    else:
+        if inside_python:
+            raise AssertionError(f"{README.name} Quickstart ```python block is never closed.")
+
+    if not body:
+        raise AssertionError(
+            f"{README.name} has a '{QUICKSTART_HEADING}' section with no ```python block. "
+            "If the snippet moved, point this guard at its new home rather than deleting it."
+        )
+    if not "\n".join(body).strip():
+        raise AssertionError(f"{README.name} Quickstart ```python block is empty.")
+    return "\n".join(body) + "\n"
+
+
+@pytest.fixture(scope="module")
+def snippet() -> str:
+    return _quickstart_snippet()
+
+
+def test_the_quickstart_block_is_locatable(snippet: str) -> None:
+    """The floor under the execution test, which would pass vacuously on an empty snippet."""
+    assert "mloda.run_all" in snippet, f"Quickstart snippet no longer calls mloda.run_all:\n{snippet}"
+
+
+def test_the_quickstart_snippet_runs_and_returns_rows(
+    snippet: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Run the snippet verbatim and assert it produces signal, not just absence of errors."""
+    # The snippet writes sample.ttl into the current directory, so it must not run in the repo tree.
+    monkeypatch.chdir(tmp_path)
+
+    namespace: dict[str, Any] = {"__name__": "__readme_quickstart__"}
+    exec(compile(snippet, f"{README.name}:Quickstart", "exec"), namespace)
+
+    feature = namespace.get("feature")
+    assert feature is not None, "Quickstart snippet no longer binds a 'feature' name this guard can read."
+
+    partitions = namespace.get("partitions")
+    assert partitions is not None, "Quickstart snippet no longer binds a 'partitions' name this guard can read."
+
+    rows = [row for partition in partitions for row in partition.get(feature.name, [])]
+    assert rows, (
+        f"Quickstart ran but returned no rows for {feature.name}. "
+        "The snippet queries a three-triple graph with two foaf:knows statements, so it should match."
+    )
+
+
+def test_the_quickstart_writes_nothing_into_the_repository(
+    snippet: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """sample.ttl belongs in the tmp dir; a chdir regression here would dirty the working tree."""
+    monkeypatch.chdir(tmp_path)
+
+    namespace: dict[str, Any] = {"__name__": "__readme_quickstart__"}
+    exec(compile(snippet, f"{README.name}:Quickstart", "exec"), namespace)
+
+    assert (tmp_path / "sample.ttl").is_file(), "Quickstart no longer writes sample.ttl where this guard expects it."
+    assert not (REPO_ROOT / "sample.ttl").exists(), "Quickstart wrote sample.ttl into the repository working tree."

--- a/uv.lock
+++ b/uv.lock
@@ -911,7 +911,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'kg-ontology'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'kg-semantic-field'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'kg-rdf'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "tox", marker = "extra == 'dev'" },
     { name = "tox-uv", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.11.6" },


### PR DESCRIPTION
Closes #57.

Adds `tests/test_readme_quickstart.py`, following the drift-guard style of `test_demo_data.py` and the end-to-end execution style of `test_demo_notebooks.py`.

## Locating, not copying

The snippet is extracted from `README.md` at test time. A copy in the test file would drift from the page silently, and that drift is the failure being guarded — so a README restructure has to fail loudly instead of turning into a skipped test. Four distinct raises cover that: no `## Quickstart` heading, a Quickstart section with no ` ```python ` block, an unclosed fence, and an empty block. Each names what moved.

One implementation note worth flagging: a `^#{1,6} ` heading regex does **not** work here. The snippet's own comments — `# Point at any RDF file.`, `# Importing the plugin module registers the rdflib_sparql feature group.` — match it, so the first attempt found the section ending *inside* the code block and reported "no python block". The scanner tracks fence state and only tests for a heading outside a fence.

## What the tests assert

| test | asserts |
| --- | --- |
| `test_the_quickstart_block_is_locatable` | the extracted block still calls `mloda.run_all` — the floor under the execution test, which would pass vacuously on an empty snippet |
| `test_the_quickstart_snippet_runs_and_returns_rows` | the snippet runs verbatim and yields **at least one row** for the requested feature |
| `test_the_quickstart_writes_nothing_into_the_repository` | `sample.ttl` lands in `tmp_path`, and does not exist in the repo root |

Execution runs under `monkeypatch.chdir(tmp_path)`, since the snippet writes `sample.ttl` into the current working directory.

## Verified non-vacuous

Mutated `README.md` five ways, one per run, restoring in between. Every mutation was caught:

| mutation | result |
| --- | --- |
| option key `query_text` → `query_string` | 2 failed |
| reader key `rdflib_sparql` → `rdflib_sparql_v2` | 2 failed |
| query `foaf:knows` → `foaf:nonsuch` (still valid, matches nothing) | 1 failed |
| heading `## Quickstart` → `## Getting started` | 3 errors |
| fence ` ```python ` → ` ```py ` | 3 errors |

The `foaf:nonsuch` case is the one that only the row assertion catches — the snippet still runs clean and raises nothing, it just returns an empty result. That is the "vacuous result" the issue asks about in step 4.

`README.md` was restored byte-for-byte afterwards; this branch touches no file but the new test.

## Gates

```
pytest -m "not notebooks"   1041 passed, 57 skipped
ruff format --check          147 files already formatted
ruff check                   All checks passed!
mypy --strict                no issues found in 136 source files
bandit -c pyproject.toml -r  0 issues
```

(`bandit` excludes `tests/` per `pyproject.toml`, so the `exec` of the extracted snippet raises no B102.)
