### PR TITLE
chore(deps): bump mloda to 0.11.0

### DIFF
--- a/open_kgo/feature_groups/kg/README.md
+++ b/open_kgo/feature_groups/kg/README.md
@@ -67,10 +67,10 @@ A concrete plugin (e.g. `RdfLibSparqlReader`) is a `ReadDB` subclass with:
   `load_data(data_access, features)` — the methods mloda's
   `BaseInputData.load` calls.
 
-Properties are declared in `PROPERTY_MAPPING` per the data-operations
-discipline (`DefaultOptionKeys.context: True`,
-`DefaultOptionKeys.strict_validation: True/False`). Strict-validation enums are
-checked in `is_valid_credentials` (inherited from the universal base).
+Properties are declared in `PROPERTY_MAPPING` as `PropertySpec` values built
+via `kg/spec.py`'s `property_spec(explanation, strict=..., allowed_values=...,
+default=...)` wrapper. Strict-validation enums are checked in
+`is_valid_credentials` (inherited from the universal base).
 
 ### Honest surface: two narrowing tools
 

--- a/open_kgo/feature_groups/kg/class_guards.py
+++ b/open_kgo/feature_groups/kg/class_guards.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping
 
-from mloda.provider import PropertySpec
+from mloda.provider import PropertySpec, is_no_default
 
 from open_kgo.feature_groups.kg.credentials import spec_allowed_values
 from open_kgo.feature_groups.kg.errors import NonDictSpecError
@@ -40,6 +40,12 @@ def validate_mapping_spec_shapes(cls: type[KgConnectorReaderBase]) -> None:
     mapping was assembled. Raises ``NonDictSpecError`` (the same typed
     error ``compose_property_mapping`` uses) so callers can catch both
     compose-time and class-definition-time bypasses with one handler.
+
+    Also rejects a spec with no declared default (core's ``NO_DEFAULT``
+    sentinel): every KG spec declares an explicit default, ``None`` for
+    "no value by default", so credential-slot code that reads
+    ``spec.default`` can treat it as a plain value without special-casing
+    the sentinel.
     """
     for layer_name in ("PROPERTY_MAPPING", "PARAMS_MAPPING"):
         mapping = getattr(cls, layer_name, None)
@@ -48,6 +54,12 @@ def validate_mapping_spec_shapes(cls: type[KgConnectorReaderBase]) -> None:
         for key, spec in mapping.items():
             if not isinstance(spec, PropertySpec):
                 raise NonDictSpecError(key, spec, context=f"{cls.__name__}.{layer_name}")
+            if is_no_default(spec.default):
+                raise ValueError(
+                    f"{cls.__name__}.{layer_name}[{key!r}] declares no default; mloda's PropertySpec "
+                    f"treats an omitted default as required. Every KG spec must declare one explicitly, "
+                    f"pass default=None to property_spec(...) for 'no value by default'."
+                )
 
 
 def validate_supported_values_invariant(cls: type[KgConnectorReaderBase]) -> None:

--- a/open_kgo/feature_groups/kg/class_guards.py
+++ b/open_kgo/feature_groups/kg/class_guards.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any, Mapping
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 from open_kgo.feature_groups.kg.credentials import spec_allowed_values
 from open_kgo.feature_groups.kg.errors import NonDictSpecError
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 def validate_mapping_spec_shapes(cls: type[KgConnectorReaderBase]) -> None:
-    """Reject non-dict spec values in ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` at class-definition time.
+    """Reject non-``PropertySpec`` spec values in ``PROPERTY_MAPPING`` / ``PARAMS_MAPPING`` at class-definition time.
 
     ``compose_property_mapping`` already enforces this for mappings built
     through the helper, but concretes that hand-assemble their mapping
@@ -36,7 +36,7 @@ def validate_mapping_spec_shapes(cls: type[KgConnectorReaderBase]) -> None:
     ``FileFixtureRestReader``, ``FileFixtureCitationReader``,
     ``InProcessTupleStoreReader``) bypass the compose-time check. Running
     the same guard once more here closes that hole so the rule is
-    "any spec in any mapping must be a dict" regardless of how the
+    "any spec in any mapping must be a PropertySpec" regardless of how the
     mapping was assembled. Raises ``NonDictSpecError`` (the same typed
     error ``compose_property_mapping`` uses) so callers can catch both
     compose-time and class-definition-time bypasses with one handler.
@@ -46,7 +46,7 @@ def validate_mapping_spec_shapes(cls: type[KgConnectorReaderBase]) -> None:
         if not mapping:
             continue
         for key, spec in mapping.items():
-            if not isinstance(spec, dict):
+            if not isinstance(spec, PropertySpec):
                 raise NonDictSpecError(key, spec, context=f"{cls.__name__}.{layer_name}")
 
 
@@ -82,7 +82,7 @@ def validate_supported_values_invariant(cls: type[KgConnectorReaderBase]) -> Non
                 f"{cls.__name__}.SUPPORTED_VALUES[{key!r}] names a key not present in "
                 f"PROPERTY_MAPPING or PARAMS_MAPPING."
             )
-        if spec.get(DefaultOptionKeys.strict_validation) is not True:
+        if spec.strict_validation is not True:
             raise ValueError(
                 f"{cls.__name__}.SUPPORTED_VALUES[{key!r}] requires the spec to set "
                 f"strict_validation=True; narrowing a non-strict key is meaningless."
@@ -99,7 +99,7 @@ def validate_supported_values_invariant(cls: type[KgConnectorReaderBase]) -> Non
                 f"{cls.__name__}.SUPPORTED_VALUES[{key!r}]={sorted(narrowed)} is not a "
                 f"subset of the family-allowed set {sorted(allowed)}."
             )
-        default = spec.get(DefaultOptionKeys.default)
+        default = spec.default
         if (
             key in cls.PROPERTY_MAPPING
             and default is not None

--- a/open_kgo/feature_groups/kg/composition.py
+++ b/open_kgo/feature_groups/kg/composition.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from mloda.provider import PropertySpec
+
 from open_kgo.feature_groups.kg.errors import NonDictSpecError, PropertyMappingCollision
 
 if TYPE_CHECKING:
@@ -15,13 +17,13 @@ if TYPE_CHECKING:
 
 
 def compose_property_mapping(*sources: dict[str, Any], context: str = "") -> dict[str, Any]:
-    """Merge property-mapping dicts, raising on duplicate keys or non-dict spec values."""
+    """Merge property-mapping dicts, raising on duplicate keys or non-PropertySpec spec values."""
     merged: dict[str, Any] = {}
     for source in sources:
         for key, spec in source.items():
             if key in merged:
                 raise PropertyMappingCollision(key, context=context)
-            if not isinstance(spec, dict):
+            if not isinstance(spec, PropertySpec):
                 raise NonDictSpecError(key, spec, context=context)
             merged[key] = spec
     return merged

--- a/open_kgo/feature_groups/kg/credentials.py
+++ b/open_kgo/feature_groups/kg/credentials.py
@@ -19,8 +19,7 @@ from __future__ import annotations
 import os
 from typing import TYPE_CHECKING, Any
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.provider import HashableDict
+from mloda.provider import HashableDict, PropertySpec
 
 from open_kgo.feature_groups.kg.errors import (
     InvalidCredentialShape,
@@ -133,7 +132,7 @@ def validate_mapping(
                     f"{cls.CONNECTOR_ID}: unknown {kind} {key!r}; allowed: {sorted(mapping.keys())}"
                 )
             continue
-        if spec.get(DefaultOptionKeys.strict_validation) is True:
+        if spec.strict_validation is True:
             narrowed = cls.SUPPORTED_VALUES.get(key)
             if narrowed is not None:
                 if value not in narrowed:
@@ -149,17 +148,17 @@ def validate_mapping(
                     )
 
 
-def spec_allowed_values(key: str, spec: dict[str, Any]) -> set[Any]:
+def spec_allowed_values(key: str, spec: PropertySpec) -> set[Any]:
     """Return the explicit ``allowed_values`` set declared on a strict-validation spec.
 
     Strict-validation specs must declare their value space explicitly via
-    the core ``DefaultOptionKeys.allowed_values`` field (a dict mapping value
+    the core ``PropertySpec.allowed_values`` field (a dict mapping value
     to its docstring, or any iterable of values). Deriving the set from the
     spec's plain string keys would silently expand the allowed set whenever a
     future doc-only key like ``"see_also"`` is added; the explicit field
     separates docs from validation data.
     """
-    raw = spec.get(DefaultOptionKeys.allowed_values)
+    raw = spec.allowed_values
     if raw is None:
         raise InvalidCredentialShape(
             f"spec for {key!r} declares strict_validation=True but is missing 'allowed_values'."

--- a/open_kgo/feature_groups/kg/errors.py
+++ b/open_kgo/feature_groups/kg/errors.py
@@ -62,12 +62,12 @@ class PropertyMappingCollision(InvalidCredentialShape):
 
 
 class NonDictSpecError(InvalidCredentialShape):
-    """Raised when a PROPERTY_MAPPING / PARAMS_MAPPING entry's spec value is not a dict.
+    """Raised when a PROPERTY_MAPPING / PARAMS_MAPPING entry's spec value is not a ``PropertySpec``.
 
     Sibling to ``PropertyMappingCollision``: both signal compose-time /
     class-definition-time misconfiguration of a property-mapping source, and
     both inherit from ``InvalidCredentialShape`` so callers can scope a
-    single handler across the whole structural-error family. A non-dict
+    single handler across the whole structural-error family. A malformed
     spec (typically ``None`` from a stale stub) would otherwise propagate
     to ``_validate_mapping`` and surface as a self-contradicting "unknown
     key" error because ``mapping.get(key) is None`` cannot distinguish a
@@ -77,8 +77,8 @@ class NonDictSpecError(InvalidCredentialShape):
     def __init__(self, key: str, spec: object, context: str = "") -> None:
         prefix = f"{context}: " if context else ""
         super().__init__(
-            f"{prefix}spec for key {key!r} must be a dict, got {type(spec).__name__} ({spec!r}). "
-            f"Non-dict specs would surface downstream as self-contradicting 'unknown key' errors."
+            f"{prefix}spec for key {key!r} must be a PropertySpec, got {type(spec).__name__} ({spec!r}). "
+            f"Malformed specs would surface downstream as self-contradicting 'unknown key' errors."
         )
         self.key = key
         self.spec = spec

--- a/open_kgo/feature_groups/kg/reader_base.py
+++ b/open_kgo/feature_groups/kg/reader_base.py
@@ -68,7 +68,7 @@ from types import MappingProxyType
 from typing import Any, ClassVar, Mapping
 
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
-from mloda.provider import HashableDict
+from mloda.provider import HashableDict, PropertySpec
 from mloda_plugins.feature_group.input_data.read_db import ReadDB
 
 from open_kgo.feature_groups.kg import class_guards, composition, credentials as credential_rules
@@ -453,7 +453,7 @@ class KgConnectorReaderBase(ReadDB):
         credential_rules.validate_mapping(cls, values, mapping, kind=kind, closed_world=closed_world)
 
     @staticmethod
-    def _spec_allowed_values(key: str, spec: dict[str, Any]) -> set[Any]:
+    def _spec_allowed_values(key: str, spec: PropertySpec) -> set[Any]:
         """Return a strict-validation spec's allowed set; see ``credentials.spec_allowed_values``."""
         return credential_rules.spec_allowed_values(key, spec)
 

--- a/open_kgo/feature_groups/kg/saas_authz/in_process_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/in_process_tuple_store.py
@@ -58,6 +58,7 @@ declare a closed ``allowed_values`` for ``SUPPORTED_VALUES`` to narrow.
 
 from __future__ import annotations
 
+import dataclasses
 from pathlib import Path
 from typing import Any, ClassVar, Mapping
 
@@ -71,7 +72,6 @@ from open_kgo.feature_groups.kg.saas_authz.base import (
     SaasAuthzReader,
 )
 from open_kgo.feature_groups.kg.saas_authz.shared import AuthzTuple, validate_tuples
-from open_kgo.feature_groups.kg.spec import property_spec
 
 
 class InProcessTupleStoreReader(SaasAuthzReader):
@@ -127,9 +127,10 @@ class InProcessTupleStoreReader(SaasAuthzReader):
     # ``tenant``; see module docstring.
     PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
         **narrow_property_mapping(SaasAuthzReader.PROPERTY_MAPPING, "locator"),
-        "tenant": property_spec(
-            "Sole tenant served by the in-process tuple store fixture.",
-            strict=True,
+        "tenant": dataclasses.replace(
+            SaasAuthzReader.PROPERTY_MAPPING["tenant"],
+            explanation="Sole tenant served by the in-process tuple store fixture.",
+            strict_validation=True,
             allowed_values={"tenant_a": "Sample tenant pre-loaded in the canonical demo fixture."},
         ),
     }
@@ -186,5 +187,5 @@ _spec_tenants = frozenset(InProcessTupleStoreReader.PROPERTY_MAPPING["tenant"].a
 if _supported_tenants != _spec_tenants:
     raise RuntimeError(
         f"InProcessTupleStoreReader: SUPPORTED_VALUES['tenant']={sorted(_supported_tenants)} drifted from "
-        f"PROPERTY_MAPPING['tenant']['allowed_values']={sorted(_spec_tenants)}; update both sides in sync."
+        f"PROPERTY_MAPPING['tenant'].allowed_values={sorted(_spec_tenants)}; update both sides in sync."
     )

--- a/open_kgo/feature_groups/kg/saas_authz/in_process_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/in_process_tuple_store.py
@@ -61,7 +61,6 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, ClassVar, Mapping
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 
 from open_kgo.feature_groups.kg.base import LoadContext, narrow_property_mapping
@@ -72,6 +71,7 @@ from open_kgo.feature_groups.kg.saas_authz.base import (
     SaasAuthzReader,
 )
 from open_kgo.feature_groups.kg.saas_authz.shared import AuthzTuple, validate_tuples
+from open_kgo.feature_groups.kg.spec import property_spec
 
 
 class InProcessTupleStoreReader(SaasAuthzReader):
@@ -127,12 +127,11 @@ class InProcessTupleStoreReader(SaasAuthzReader):
     # ``tenant``; see module docstring.
     PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
         **narrow_property_mapping(SaasAuthzReader.PROPERTY_MAPPING, "locator"),
-        "tenant": {
-            **SaasAuthzReader.PROPERTY_MAPPING["tenant"],
-            "explanation": "Sole tenant served by the in-process tuple store fixture.",
-            "allowed_values": {"tenant_a": "Sample tenant pre-loaded in the canonical demo fixture."},
-            DefaultOptionKeys.strict_validation: True,
-        },
+        "tenant": property_spec(
+            "Sole tenant served by the in-process tuple store fixture.",
+            strict=True,
+            allowed_values={"tenant_a": "Sample tenant pre-loaded in the canonical demo fixture."},
+        ),
     }
 
     @classmethod
@@ -183,7 +182,7 @@ class InProcessTupleStoreFeatureGroup(SaasAuthzFeatureGroup):
 # explicit ``raise`` instead of ``assert`` so the check survives ``python -O``
 # and doesn't trip bandit B101.
 _supported_tenants = InProcessTupleStoreReader.SUPPORTED_VALUES["tenant"]
-_spec_tenants = frozenset(InProcessTupleStoreReader.PROPERTY_MAPPING["tenant"]["allowed_values"].keys())
+_spec_tenants = frozenset(InProcessTupleStoreReader.PROPERTY_MAPPING["tenant"].allowed_values.keys())
 if _supported_tenants != _spec_tenants:
     raise RuntimeError(
         f"InProcessTupleStoreReader: SUPPORTED_VALUES['tenant']={sorted(_supported_tenants)} drifted from "

--- a/open_kgo/feature_groups/kg/saas_authz/tests/test_in_process_tuple_store.py
+++ b/open_kgo/feature_groups/kg/saas_authz/tests/test_in_process_tuple_store.py
@@ -90,5 +90,5 @@ class TestInProcessTupleStoreReader(SaasAuthzContractTestBase):
         ``UnknownTenantError``. This test fails the build on either drift.
         """
         fixture_data = json.loads(InProcessTupleStoreReader._FIXTURE_PATH.read_text(encoding="utf-8"))
-        allowed = set(InProcessTupleStoreReader.PROPERTY_MAPPING["tenant"]["allowed_values"])
+        allowed = set(InProcessTupleStoreReader.PROPERTY_MAPPING["tenant"].allowed_values)
         assert allowed == set(fixture_data)

--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -19,8 +19,6 @@ from typing import Any
 
 from mloda.provider import PropertySpec, property_spec as _core_property_spec
 
-_AllowedValues = Mapping[Any, str] | tuple[Any, ...] | list[Any] | set[Any] | frozenset[Any]
-
 
 def property_spec(
     explanation: str,
@@ -35,15 +33,17 @@ def property_spec(
     ``allowed_values`` accepts any iterable (a generator included) for caller
     convenience; anything that isn't already one of core's accepted concrete
     shapes is materialized into a tuple before reaching core, whose own type
-    is narrower.
+    is narrower. A ``str``/``bytes`` value is passed through unmaterialized so
+    core's own guard rejects it (materializing it here would silently explode
+    it into a tuple of characters instead).
     """
     if allowed_values is not None and not strict:
         raise ValueError(
             f"property_spec({explanation!r}): allowed_values is never enforced without strict=True. "
             f"Pass strict=True, or drop allowed_values."
         )
-    materialized: _AllowedValues | None
-    if allowed_values is None or isinstance(allowed_values, Mapping):
+    materialized: Any
+    if allowed_values is None or isinstance(allowed_values, (Mapping, str, bytes)):
         materialized = allowed_values
     else:
         materialized = tuple(allowed_values)

--- a/open_kgo/feature_groups/kg/spec.py
+++ b/open_kgo/feature_groups/kg/spec.py
@@ -3,9 +3,9 @@
 Core owns the builder and its invariants (see mloda-ai/open-kgo#29); this wrapper
 adds two open-kgo conventions:
 
-- ``default`` is always emitted (explicit ``None`` when unset) so KG specs read
-  uniformly via subscript. The key is in core's ``PROPERTY_SPEC_KEYS``, so core's
-  own parser ignores it.
+- ``default`` defaults to ``None`` rather than core's ``NO_DEFAULT``, so a KG spec
+  is optional unless the caller explicitly opts into a different default. Core's
+  ``PropertySpec`` treats an omitted ``default`` as required (mloda>=0.11.0).
 - ``allowed_values`` requires ``strict=True``. Core permits a non-strict value
   space (it still maps a name-parsed value back onto its key), but KG specs are
   never name-parsed and ``_validate_mapping`` enforces the set only under
@@ -17,8 +17,9 @@ from __future__ import annotations
 from collections.abc import Iterable, Mapping
 from typing import Any
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-from mloda.provider import property_spec as _core_property_spec
+from mloda.provider import PropertySpec, property_spec as _core_property_spec
+
+_AllowedValues = Mapping[Any, str] | tuple[Any, ...] | list[Any] | set[Any] | frozenset[Any]
 
 
 def property_spec(
@@ -28,19 +29,28 @@ def property_spec(
     allowed_values: Mapping[Any, str] | Iterable[Any] | None = None,
     default: Any = None,
     context: bool = True,
-) -> dict[str, Any]:
-    """Build a PROPERTY_MAPPING spec dict via core, keeping ``default`` always present."""
+) -> PropertySpec:
+    """Build a PROPERTY_MAPPING ``PropertySpec`` via core, defaulting to optional.
+
+    ``allowed_values`` accepts any iterable (a generator included) for caller
+    convenience; anything that isn't already one of core's accepted concrete
+    shapes is materialized into a tuple before reaching core, whose own type
+    is narrower.
+    """
     if allowed_values is not None and not strict:
         raise ValueError(
             f"property_spec({explanation!r}): allowed_values is never enforced without strict=True. "
             f"Pass strict=True, or drop allowed_values."
         )
-    spec = _core_property_spec(
+    materialized: _AllowedValues | None
+    if allowed_values is None or isinstance(allowed_values, Mapping):
+        materialized = allowed_values
+    else:
+        materialized = tuple(allowed_values)
+    return _core_property_spec(
         explanation,
         strict=strict,
-        allowed_values=allowed_values,
+        allowed_values=materialized,
         default=default,
         context=context,
     )
-    spec.setdefault(DefaultOptionKeys.default, None)
-    return spec

--- a/open_kgo/feature_groups/kg/tests/_discovery.py
+++ b/open_kgo/feature_groups/kg/tests/_discovery.py
@@ -33,7 +33,7 @@ import textwrap
 from contextlib import contextmanager
 from typing import Any, Iterator, Literal
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 import open_kgo.feature_groups.kg as _kg_pkg
 from open_kgo.feature_groups.kg.base import KgConnectorReaderBase, ParamReader
@@ -147,13 +147,13 @@ def clean_kg_subclass_registry() -> Iterator[None]:
 
 def iter_strict_specs(
     reader_class: type[KgConnectorReaderBase],
-) -> Iterator[tuple[str, dict[str, Any], _LayerName]]:
+) -> Iterator[tuple[str, PropertySpec, _LayerName]]:
     """Yield ``(key, spec, layer_name)`` for every strict-validation spec on ``reader_class``.
 
     Walks ``PROPERTY_MAPPING`` for every reader and ``PARAMS_MAPPING`` for
     ``ParamReader`` subclasses only (``QueryReader`` subclasses don't carry
-    one). The ``isinstance(spec, dict)`` guard is defensive: class-time
-    ``_validate_mapping_spec_shapes`` already rejects non-dict specs, so
+    one). The ``isinstance(spec, PropertySpec)`` guard is defensive: class-time
+    ``_validate_mapping_spec_shapes`` already rejects malformed specs, so
     in practice the guard is unreachable through a valid class. The
     integrity check for those lives in ``test_property_mapping_integrity.py``.
 
@@ -167,15 +167,15 @@ def iter_strict_specs(
         layers.append(("PARAMS_MAPPING", reader_class.PARAMS_MAPPING))
     for layer_name, mapping in layers:
         for key, spec in mapping.items():
-            if not isinstance(spec, dict):
+            if not isinstance(spec, PropertySpec):
                 continue
-            if spec.get(DefaultOptionKeys.strict_validation) is True:
+            if spec.strict_validation is True:
                 yield key, spec, layer_name
 
 
 def iter_nonstrict_specs(
     reader_class: type[KgConnectorReaderBase],
-) -> Iterator[tuple[str, dict[str, Any], _LayerName]]:
+) -> Iterator[tuple[str, PropertySpec, _LayerName]]:
     """Yield ``(key, spec, layer_name)`` for every NON-strict-validation spec on ``reader_class``.
 
     The complement of ``iter_strict_specs`` over the same layers, so the
@@ -189,9 +189,9 @@ def iter_nonstrict_specs(
         layers.append(("PARAMS_MAPPING", reader_class.PARAMS_MAPPING))
     for layer_name, mapping in layers:
         for key, spec in mapping.items():
-            if not isinstance(spec, dict):
+            if not isinstance(spec, PropertySpec):
                 continue
-            if spec.get(DefaultOptionKeys.strict_validation) is not True:
+            if spec.strict_validation is not True:
                 yield key, spec, layer_name
 
 

--- a/open_kgo/feature_groups/kg/tests/_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/_helpers.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import PropertySpec
 from mloda.user import DataAccessCollection, Feature, mloda
 
 from open_kgo.feature_groups.kg.base import KgConnectorReaderBase, PythonDictFramework
@@ -81,18 +81,14 @@ def make_valid_credentials(
     What this helper does fix is the hand-rolled slot-dict duplication
     across scenarios within a single concrete test file.
 
-    Defaults are read via ``DefaultOptionKeys.default`` (not the bare
-    string), matching the spec authoring convention in
+    Defaults are read via ``PropertySpec.default`` (not the bare string),
+    matching the spec authoring convention in
     ``open_kgo/feature_groups/kg/base.py``. ``None`` defaults are
-    treated as "no default to apply" — the spec uses ``None`` to make
+    treated as "no default to apply": the spec uses ``None`` to make
     "absence is intentional" explicit for optional keys like ``locator``
     or family-level pin keys (``species_prefix``, ``dataset_version``,
     ``stable_id``), and pre-filling them with ``None`` would only invite
-    a redundant ``slot.pop(key)`` at every call site. The same branch
-    also covers specs that omit the ``default`` field entirely
-    (``spec.get`` returns ``None``); since every KG spec under
-    ``base.py`` declares ``default`` explicitly, that case currently
-    never fires, but the behaviour is intentional and not accidental.
+    a redundant ``slot.pop(key)`` at every call site.
 
     When ``validate=True`` (default), the resulting slot runs through
     ``reader_class._validate_shape`` so a missing-required-key or
@@ -102,9 +98,9 @@ def make_valid_credentials(
     """
     slot: dict[str, Any] = {}
     for key, spec in reader_class.PROPERTY_MAPPING.items():
-        if not isinstance(spec, dict):
+        if not isinstance(spec, PropertySpec):
             continue
-        default = spec.get(DefaultOptionKeys.default)
+        default = spec.default
         if default is None:
             continue
         slot[key] = default
@@ -143,7 +139,7 @@ def canonical_row_key(row: Any) -> str:
     return repr(_canonical(row))
 
 
-def bogus_value_for_strict_spec(spec: dict[str, Any]) -> Any:
+def bogus_value_for_strict_spec(spec: PropertySpec) -> Any:
     """Return a value guaranteed not to be in this strict spec's allowed set.
 
     Type-coheres to the existing allowed values when possible — prefers a
@@ -177,8 +173,8 @@ def bogus_value_for_strict_spec(spec: dict[str, Any]) -> Any:
       ``allowed_values`` survives ``_validate_mapping``'s upstream
       check and lands here too.
 
-    The helper accepts only the spec dict — not a separately-supplied
-    "narrowed" set — because ``SUPPORTED_VALUES`` is enforced at class
+    The helper accepts only the spec, not a separately-supplied
+    "narrowed" set, because ``SUPPORTED_VALUES`` is enforced at class
     definition time to be a subset of the family-allowed set (see
     ``KgConnectorReaderBase._validate_supported_values_invariant`` in
     ``base.py``). A value outside the family set is therefore also
@@ -191,7 +187,7 @@ def bogus_value_for_strict_spec(spec: dict[str, Any]) -> Any:
     signature may evolve to use its currently-message-only ``key``
     argument for behaviour.
     """
-    raw = spec.get("allowed_values")
+    raw = spec.allowed_values
     if raw is None:
         return object()
     allowed: set[Any] = set(raw.keys()) if isinstance(raw, dict) else set(raw)

--- a/open_kgo/feature_groups/kg/tests/contract_surface.py
+++ b/open_kgo/feature_groups/kg/tests/contract_surface.py
@@ -9,7 +9,7 @@ explicit disposition; see the "Honest credential surface" section in
 
 from __future__ import annotations
 
-from typing import Any
+from mloda.provider import PropertySpec
 
 from open_kgo.feature_groups.kg.tests._discovery import (
     effective_unconsumed_waivers,
@@ -49,7 +49,7 @@ class SurfaceHonestyContract(KgContractAdapterBase):
         surface.
         """
         cls = self.connector_reader_class()
-        lies: list[tuple[str, str, dict[str, Any]]] = []
+        lies: list[tuple[str, str, PropertySpec]] = []
         for key, spec, layer_name in iter_strict_specs(cls):
             if key in cls.SUPPORTED_VALUES:
                 continue

--- a/open_kgo/feature_groups/kg/tests/test_cross_layer_pagination.py
+++ b/open_kgo/feature_groups/kg/tests/test_cross_layer_pagination.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.user import Feature, Options
 
@@ -206,7 +205,7 @@ def test_pagination_style_classifications_match_declared_values() -> None:
     from open_kgo.feature_groups.kg.mixins import _PAGINATION_STYLES, PaginationMixin
 
     style_spec = PaginationMixin.PROPERTY_MAPPING_DELTA["pagination_style"]
-    declared = set(style_spec["allowed_values"].keys())
+    declared = set(style_spec.allowed_values.keys())
     classified = set(_PAGINATION_STYLES.keys())
     assert declared == classified, (
         f"pagination_style declarations and family classifications drifted: "
@@ -222,7 +221,7 @@ def test_pagination_style_classifications_match_declared_values() -> None:
         f"only {sorted(valid_family_tags)} feed into _CURSOR_FAMILY_STYLES."
     )
 
-    spec_default = style_spec[DefaultOptionKeys.default]
+    spec_default = style_spec.default
     assert spec_default in _PAGINATION_STYLES, f"pagination_style default {spec_default!r} is not a declared style."
     assert spec_default == "none", (
         "PaginationMixin._validate_cross_layer hard-codes 'none' as the fallback "

--- a/open_kgo/feature_groups/kg/tests/test_discovery_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/test_discovery_helpers.py
@@ -27,7 +27,7 @@ from typing import Any, ClassVar
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import property_spec
 
 from open_kgo.feature_groups.kg.base import KgConnectorReaderBase, ParamReader, QueryReader
 from open_kgo.feature_groups.kg.tests._discovery import (
@@ -135,9 +135,9 @@ def test_iter_strict_specs_skips_non_strict_specs() -> None:
             # synthetic reader that replaces PROPERTY_MAPPING wholesale).
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "loose": {DefaultOptionKeys.strict_validation: False, "allowed_values": ["a"]},
-                "strict": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["b"]},
-                "unset": {"allowed_values": ["c"]},
+                "loose": property_spec("loose", default=None, allowed_values=["a"]),
+                "strict": property_spec("strict", default=None, strict=True, allowed_values=["b"]),
+                "unset": property_spec("unset", default=None, allowed_values=["c"]),
             }
 
         return [key for key, _spec, _layer in iter_strict_specs(_MixedStrictness)]
@@ -155,10 +155,10 @@ def test_iter_strict_specs_includes_params_mapping_for_param_reader() -> None:
             CONNECTOR_ID = "_b3_param_reader"
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "prop_strict": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["a"]},
+                "prop_strict": property_spec("prop_strict", default=None, strict=True, allowed_values=["a"]),
             }
             PARAMS_MAPPING: ClassVar[dict[str, Any]] = {
-                "param_strict": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["b"]},
+                "param_strict": property_spec("param_strict", default=None, strict=True, allowed_values=["b"]),
             }
 
         return [(key, layer) for key, _spec, layer in iter_strict_specs(_PR)]
@@ -185,14 +185,16 @@ def test_iter_strict_specs_excludes_params_mapping_for_query_reader() -> None:
             CONNECTOR_ID = "_b3_query_reader"
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "qr_strict": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["x"]},
+                "qr_strict": property_spec("qr_strict", default=None, strict=True, allowed_values=["x"]),
             }
             # Drift: QueryReader subclass with a PARAMS_MAPPING attribute.
             # The helper must not yield its keys regardless of presence —
             # only ParamReader subclasses are supposed to declare per-call
             # params, and the helper enforces that via the issubclass gate.
             PARAMS_MAPPING: ClassVar[dict[str, Any]] = {
-                "should_not_appear": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["y"]},
+                "should_not_appear": property_spec(
+                    "should_not_appear", default=None, strict=True, allowed_values=["y"]
+                ),
             }
 
         return [(key, layer) for key, _spec, layer in iter_strict_specs(_QR)]
@@ -218,11 +220,11 @@ def test_iter_nonstrict_specs_is_the_complement_of_iter_strict_specs() -> None:
             CONNECTOR_ID = "_b4_nonstrict"
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "prop_strict": {DefaultOptionKeys.strict_validation: True, "allowed_values": ["a"]},
-                "prop_loose": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "prop_strict": property_spec("prop_strict", default=None, strict=True, allowed_values=["a"]),
+                "prop_loose": property_spec("prop_loose", default=None),
             }
             PARAMS_MAPPING: ClassVar[dict[str, Any]] = {
-                "param_loose": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "param_loose": property_spec("param_loose", default=None),
             }
 
         strict = [(k, str(layer)) for k, _s, layer in iter_strict_specs(_PR)]
@@ -247,8 +249,8 @@ def test_reader_string_literals_separates_read_keys_from_declared_only_keys() ->
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
                 # Declared but never read in any method body below.
-                "zzz_advertised_only": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
-                "zzz_consumed_key": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "zzz_advertised_only": property_spec("zzz_advertised_only", default=None),
+                "zzz_consumed_key": property_spec("zzz_consumed_key", default=None),
             }
 
             @classmethod
@@ -290,8 +292,8 @@ def test_effective_unconsumed_waivers_unions_across_mro() -> None:
         class _FamilyBase(KgConnectorReaderBase):
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "family_key": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
-                "concrete_key": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "family_key": property_spec("family_key", default=None),
+                "concrete_key": property_spec("concrete_key", default=None),
             }
             _WAIVED_UNCONSUMED_KEYS: ClassVar[frozenset[str]] = frozenset({"family_key"})
 
@@ -335,14 +337,14 @@ def test_surface_honesty_disposition_flags_a_lie_and_a_waiver_clears_it() -> Non
             CONNECTOR_ID = "_b4_lie"
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "zzz_never_read": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "zzz_never_read": property_spec("zzz_never_read", default=None),
             }
 
         class _WaivedReader(KgConnectorReaderBase):
             CONNECTOR_ID = "_b4_waived"
             SOURCE_SLOT = None
             PROPERTY_MAPPING: ClassVar[dict[str, Any]] = {
-                "zzz_never_read": {DefaultOptionKeys.strict_validation: False, DefaultOptionKeys.default: None},
+                "zzz_never_read": property_spec("zzz_never_read", default=None),
             }
             _WAIVED_UNCONSUMED_KEYS: ClassVar[frozenset[str]] = frozenset({"zzz_never_read"})
 

--- a/open_kgo/feature_groups/kg/tests/test_helpers.py
+++ b/open_kgo/feature_groups/kg/tests/test_helpers.py
@@ -31,11 +31,10 @@ family is reorganised, this module needs the new path.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import property_spec as _core_property_spec
 from mloda.user import Feature, Options
 
 from open_kgo.feature_groups.kg.citation_rest.file_fixture_citation import (
@@ -59,10 +58,7 @@ _CITATION_FIXTURE = Path(__file__).parent.parent / "citation_rest" / "tests" / "
 
 def test_bogus_value_for_strict_spec_string_allowed_values_returns_string_outside_set() -> None:
     """Mirrors the existing kg_contract.py call shape: spec with a string set."""
-    spec: dict[str, Any] = {
-        "allowed_values": {"alpha", "beta", "gamma"},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("string set", strict=True, allowed_values={"alpha", "beta", "gamma"})
     bogus = bogus_value_for_strict_spec(spec)
     assert isinstance(bogus, str)
     assert bogus not in {"alpha", "beta", "gamma"}
@@ -70,10 +66,9 @@ def test_bogus_value_for_strict_spec_string_allowed_values_returns_string_outsid
 
 def test_bogus_value_for_strict_spec_string_dict_allowed_values_uses_keys() -> None:
     """``allowed_values`` may be a dict mapping value → docstring; we extract keys."""
-    spec: dict[str, Any] = {
-        "allowed_values": {"read": "read consistency", "linearisable": "strong"},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec(
+        "dict set", strict=True, allowed_values={"read": "read consistency", "linearisable": "strong"}
+    )
     bogus = bogus_value_for_strict_spec(spec)
     assert isinstance(bogus, str)
     assert bogus not in {"read", "linearisable"}
@@ -81,10 +76,7 @@ def test_bogus_value_for_strict_spec_string_dict_allowed_values_uses_keys() -> N
 
 def test_bogus_value_for_strict_spec_avoids_canonical_candidate_when_collision() -> None:
     """If the canonical ``__bogus_strict_spec_value_0__`` is in the set, the helper sweeps."""
-    spec: dict[str, Any] = {
-        "allowed_values": {"alpha", "__bogus_strict_spec_value_0__"},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("collision", strict=True, allowed_values={"alpha", "__bogus_strict_spec_value_0__"})
     bogus = bogus_value_for_strict_spec(spec)
     assert isinstance(bogus, str)
     assert bogus not in {"alpha", "__bogus_strict_spec_value_0__"}
@@ -98,10 +90,7 @@ def test_bogus_value_for_strict_spec_int_allowed_values_returns_int_above_max() 
     refactor when a future spec adds an int enum (e.g. an HTTP status code
     set, a max-hops bound).
     """
-    spec: dict[str, Any] = {
-        "allowed_values": {1, 2, 5, 10},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("int set", strict=True, allowed_values={1, 2, 5, 10})
     bogus = bogus_value_for_strict_spec(spec)
     assert isinstance(bogus, int) and not isinstance(bogus, bool)
     assert bogus not in {1, 2, 5, 10}
@@ -121,10 +110,7 @@ def test_bogus_value_for_strict_spec_bool_allowed_values_returns_sentinel() -> N
     bool spec would receive ``max({True, False}) + 1 == 2``, which is
     still not in the set but is a semantically confusing answer.
     """
-    spec: dict[str, Any] = {
-        "allowed_values": {True, False},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("bool set", strict=True, allowed_values={True, False})
     bogus = bogus_value_for_strict_spec(spec)
     # ``object()`` is unequal to True/False; the membership check at the
     # validator's `in` returns False.
@@ -142,10 +128,7 @@ def test_bogus_value_for_strict_spec_mixed_bool_int_picks_int_branch() -> None:
     order-dependent answer the first implementation would have returned
     (``object()`` if ``True`` was sampled first, ``6`` if ``5`` was).
     """
-    spec: dict[str, Any] = {
-        "allowed_values": {True, 5},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("mixed bool int", strict=True, allowed_values={True, 5})
     bogus = bogus_value_for_strict_spec(spec)
     assert bogus == 6
     assert not isinstance(bogus, bool)
@@ -159,10 +142,7 @@ def test_bogus_value_for_strict_spec_mixed_bool_str_picks_str_branch() -> None:
     a fresh string sentinel. Pins the symmetric case to its int sibling
     so a future refactor that re-orders the branches surfaces here.
     """
-    spec: dict[str, Any] = {
-        "allowed_values": {True, "alpha"},
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("mixed bool str", strict=True, allowed_values={True, "alpha"})
     bogus = bogus_value_for_strict_spec(spec)
     assert isinstance(bogus, str)
     assert bogus not in {True, "alpha"}
@@ -172,14 +152,12 @@ def test_bogus_value_for_strict_spec_mixed_bool_str_picks_str_branch() -> None:
 def test_bogus_value_for_strict_spec_empty_allowed_returns_sentinel() -> None:
     """An empty iterable allowed_values falls through to the object() sentinel.
 
-    ``_spec_allowed_values`` rejects a *missing* ``allowed_values``, but an
-    empty *non-missing* iterable survives that check. The helper covers
-    the latter for defense-in-depth — a non-member exists trivially.
+    ``PropertySpec`` rejects a strict spec with an empty ``allowed_values``
+    unless an ``element_validator`` takes over as the value space, so that is
+    how this spec is built. The helper covers the empty-set shape for
+    defense-in-depth: a non-member exists trivially.
     """
-    spec: dict[str, Any] = {
-        "allowed_values": frozenset(),
-        DefaultOptionKeys.strict_validation: True,
-    }
+    spec = _core_property_spec("empty", strict=True, allowed_values=(), element_validator=lambda value: True)
     bogus = bogus_value_for_strict_spec(spec)
     # The sentinel is by construction outside any set.
     assert bogus not in frozenset()

--- a/open_kgo/feature_groups/kg/tests/test_property_mapping_integrity.py
+++ b/open_kgo/feature_groups/kg/tests/test_property_mapping_integrity.py
@@ -418,6 +418,30 @@ def test_init_subclass_rejects_direct_assignment_of_non_dict_spec_in_params_mapp
             }
 
 
+def test_init_subclass_rejects_spec_with_no_declared_default() -> None:
+    """A ``PropertySpec`` built without a ``default`` (core's ``NO_DEFAULT``) fails at class definition.
+
+    Core's ``property_spec`` (bypassing the KG wrapper, which always supplies
+    a default) leaves ``default`` as the ``NO_DEFAULT`` sentinel when the
+    caller omits it. Without this guard, the sentinel would leak into
+    downstream code that reads ``spec.default`` expecting a plain value or
+    ``None``.
+    """
+    from mloda.provider import property_spec as core_property_spec
+
+    from open_kgo.feature_groups.kg.agent_memory.networkx_memory import NetworkxMemoryReader
+
+    with clean_kg_subclass_registry():
+        with pytest.raises(ValueError, match="declares no default"):
+
+            class _BadNoDefault(NetworkxMemoryReader):
+                CONNECTOR_ID = "_invariant_test_no_default_spec"
+                PROPERTY_MAPPING = {
+                    **{k: v for k, v in NetworkxMemoryReader.PROPERTY_MAPPING.items()},
+                    "extra_probe_key": core_property_spec("Missing default.", strict=True, allowed_values=["a"]),
+                }
+
+
 # -- Default-value legality on strict-validation specs ------------------------
 #
 # Every strict-validation spec carries a ``default`` paired with an
@@ -432,7 +456,7 @@ def test_init_subclass_rejects_direct_assignment_of_non_dict_spec_in_params_mapp
 
 def test_strict_validation_defaults_are_legal() -> None:
     """For every ``strict_validation=True`` spec across PROPERTY_MAPPING/PARAMS_MAPPING
-    on every concrete reader, ``spec[default]`` must be in
+    on every concrete reader, ``spec.default`` must be in
     ``_spec_allowed_values(spec)`` (or be ``None``).
 
     Aggregates failures so a future spec drift surfaces every violation at

--- a/open_kgo/feature_groups/kg/tests/test_property_mapping_integrity.py
+++ b/open_kgo/feature_groups/kg/tests/test_property_mapping_integrity.py
@@ -23,7 +23,7 @@ from typing import Any, ClassVar
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
+from mloda.provider import PropertySpec
 
 from open_kgo.feature_groups.kg.agent_memory.base import (
     AgentMemoryReader,
@@ -41,6 +41,7 @@ from open_kgo.feature_groups.kg.errors import (
     NonDictSpecError,
     PropertyMappingCollision,
 )
+from open_kgo.feature_groups.kg.spec import property_spec
 from open_kgo.feature_groups.kg.tests._discovery import (
     clean_kg_subclass_registry,
     import_all_kg_readers,
@@ -248,10 +249,10 @@ def test_memory_scope_specs_propagate_into_agent_memory_property_mapping() -> No
     for name, explanation, default in _MEMORY_SCOPE_SPECS:
         assert name in declared, f"{name!r} declared in _MEMORY_SCOPE_SPECS but absent from PROPERTY_MAPPING"
         spec = declared[name]
-        assert spec["explanation"] == explanation
-        assert spec[DefaultOptionKeys.default] == default
-        assert spec[DefaultOptionKeys.context] is True
-        assert spec[DefaultOptionKeys.strict_validation] is False
+        assert spec.explanation == explanation
+        assert spec.default == default
+        assert spec.context is True
+        assert spec.strict_validation is False
 
 
 # -- compose_property_mapping duplicate handling ------------------------------
@@ -270,8 +271,8 @@ def test_memory_scope_specs_propagate_into_agent_memory_property_mapping() -> No
 
 def test_compose_property_mapping_rejects_duplicate_keys() -> None:
     """Any duplicate key across composed sources raises ``PropertyMappingCollision``."""
-    source_a = {"k": {"explanation": "first"}}
-    source_b = {"k": {"explanation": "second"}}
+    source_a = {"k": property_spec("first")}
+    source_b = {"k": property_spec("second")}
 
     with pytest.raises(PropertyMappingCollision):
         compose_property_mapping(source_a, source_b, context="test")
@@ -293,20 +294,20 @@ def test_compose_property_mapping_rejects_duplicate_keys() -> None:
 
 def test_compose_property_mapping_rejects_none_spec_value() -> None:
     """A ``None`` spec value is misconfiguration and must raise at compose time."""
-    with pytest.raises(NonDictSpecError, match=r"must be a dict"):
+    with pytest.raises(NonDictSpecError, match=r"must be a PropertySpec"):
         compose_property_mapping({"extra": None}, context="test")
 
 
 def test_compose_property_mapping_rejects_non_dict_spec_value() -> None:
     """Any non-dict spec value (string, number, list, ...) is rejected at compose time."""
-    with pytest.raises(NonDictSpecError, match=r"must be a dict"):
+    with pytest.raises(NonDictSpecError, match=r"must be a PropertySpec"):
         compose_property_mapping({"extra": "not_a_dict"}, context="test")
 
 
 def test_compose_property_mapping_rejects_none_spec_value_across_sources() -> None:
     """A ``None`` spec value in a later source is caught alongside valid earlier sources."""
-    with pytest.raises(NonDictSpecError, match=r"must be a dict"):
-        compose_property_mapping({"first": {"explanation": "ok"}}, {"second": None}, context="test")
+    with pytest.raises(NonDictSpecError, match=r"must be a PropertySpec"):
+        compose_property_mapping({"first": property_spec("ok")}, {"second": None}, context="test")
 
 
 def test_compose_property_mapping_non_dict_spec_error_is_invalid_credential_shape() -> None:
@@ -393,7 +394,7 @@ def test_init_subclass_rejects_direct_assignment_of_non_dict_spec_in_property_ma
     """A concrete that assigns ``PROPERTY_MAPPING`` with a non-dict value fails at class definition."""
     from open_kgo.feature_groups.kg.agent_memory.networkx_memory import NetworkxMemoryReader
 
-    with pytest.raises(NonDictSpecError, match=r"must be a dict"):
+    with pytest.raises(NonDictSpecError, match=r"must be a PropertySpec"):
 
         class _BadDirectAssign(NetworkxMemoryReader):
             CONNECTOR_ID = "_invariant_test_non_dict_property_spec"
@@ -407,7 +408,7 @@ def test_init_subclass_rejects_direct_assignment_of_non_dict_spec_in_params_mapp
     """A concrete that assigns ``PARAMS_MAPPING`` with a non-dict value fails at class definition."""
     from open_kgo.feature_groups.kg.code_build.base import CodeBuildReader
 
-    with pytest.raises(NonDictSpecError, match=r"must be a dict"):
+    with pytest.raises(NonDictSpecError, match=r"must be a PropertySpec"):
 
         class _BadDirectAssignParams(CodeBuildReader):
             CONNECTOR_ID = "_invariant_test_non_dict_params_spec"
@@ -444,11 +445,11 @@ def test_strict_validation_defaults_are_legal() -> None:
         for layer_name in ("PROPERTY_MAPPING", "PARAMS_MAPPING"):
             mapping: dict[str, object] = getattr(sub, layer_name, {}) or {}
             for key, spec in mapping.items():
-                if not isinstance(spec, dict):
+                if not isinstance(spec, PropertySpec):
                     continue
-                if spec.get(DefaultOptionKeys.strict_validation) is not True:
+                if spec.strict_validation is not True:
                     continue
-                default = spec.get(DefaultOptionKeys.default)
+                default = spec.default
                 if default is None:
                     continue
                 allowed = KgConnectorReaderBase._spec_allowed_values(key, spec)
@@ -492,10 +493,7 @@ def test_init_subclass_chain_propagates_invariant_failure_through_param_reader()
 # registry walk.
 
 
-_A6_NON_STRICT_SPEC: dict[str, Any] = {
-    DefaultOptionKeys.context: True,
-    DefaultOptionKeys.strict_validation: False,
-}
+_A6_NON_STRICT_SPEC = property_spec("synthetic test spec")
 
 
 def _build_three_level_chain(
@@ -694,12 +692,7 @@ def test_source_slot_invariant_accepts_declared_rename_and_baked() -> None:
             SOURCE_SLOT = "endpoint_url"
             PROPERTY_MAPPING = {
                 **narrow_property_mapping(NetworkxMemoryReader.PROPERTY_MAPPING, "locator"),
-                "endpoint_url": {
-                    "explanation": "Synthetic renamed address slot.",
-                    DefaultOptionKeys.context: True,
-                    DefaultOptionKeys.strict_validation: False,
-                    DefaultOptionKeys.default: None,
-                },
+                "endpoint_url": property_spec("Synthetic renamed address slot."),
             }
 
         class _DeclaredBaked(NetworkxMemoryReader):

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -10,19 +10,16 @@ from __future__ import annotations
 
 import pytest
 
-from mloda.provider import property_spec as _core_property_spec
+from mloda.provider import PropertySpec, property_spec as _core_property_spec
 
 from open_kgo.feature_groups.kg.spec import property_spec
 
 
 class TestPropertySpecEmission:
-    def test_non_strict_spec_emits_conventional_dict(self) -> None:
-        """The emitted ``PropertySpec`` matches the hand-written fields."""
+    def test_non_strict_spec_emits_expected_fields(self) -> None:
+        """The emitted ``PropertySpec`` matches the hand-written fields exactly."""
         emitted = property_spec("Endpoint URL or filesystem path.", default=1000)
-        assert emitted.explanation == "Endpoint URL or filesystem path."
-        assert emitted.context is True
-        assert emitted.strict_validation is False
-        assert emitted.default == 1000
+        assert emitted == PropertySpec("Endpoint URL or filesystem path.", default=1000)
 
     def test_strict_spec_emits_allowed_values_unchanged(self) -> None:
         """``allowed_values`` passes through by reference so doc-dicts survive intact."""
@@ -77,3 +74,12 @@ class TestPropertySpecInvariants:
         no_values: tuple[str, ...] = ()
         with pytest.raises(ValueError, match="empty allowed_values would reject"):
             property_spec("Empty generator.", strict=True, allowed_values=(v for v in no_values))
+
+    def test_string_allowed_values_rejected(self) -> None:
+        """A bare string is iterable, so it must not silently explode into per-character values."""
+        with pytest.raises(ValueError, match="substring test"):
+            property_spec("Typo'd enum.", strict=True, allowed_values="tenant_a")
+
+    def test_bytes_allowed_values_rejected(self) -> None:
+        with pytest.raises(ValueError, match="substring test"):
+            property_spec("Typo'd enum.", strict=True, allowed_values=b"tenant_a")

--- a/open_kgo/feature_groups/kg/tests/test_spec.py
+++ b/open_kgo/feature_groups/kg/tests/test_spec.py
@@ -2,7 +2,7 @@
 
 The wrapper delegates construction and invariant validation to mloda core
 (``mloda.provider.property_spec``); these tests pin the two open-kgo-specific
-behaviors it adds (``default`` always emitted, ``allowed_values`` requires
+behaviors it adds (``default`` defaults to ``None``, ``allowed_values`` requires
 strict) and confirm core's validation is in force through the wrapper.
 """
 
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.provider import property_spec as _core_property_spec
 
 from open_kgo.feature_groups.kg.spec import property_spec
@@ -18,27 +17,25 @@ from open_kgo.feature_groups.kg.spec import property_spec
 
 class TestPropertySpecEmission:
     def test_non_strict_spec_emits_conventional_dict(self) -> None:
-        """The emitted dict matches the hand-written literal shape byte-for-byte."""
+        """The emitted ``PropertySpec`` matches the hand-written fields."""
         emitted = property_spec("Endpoint URL or filesystem path.", default=1000)
-        assert emitted == {
-            "explanation": "Endpoint URL or filesystem path.",
-            DefaultOptionKeys.context: True,
-            DefaultOptionKeys.strict_validation: False,
-            DefaultOptionKeys.default: 1000,
-        }
+        assert emitted.explanation == "Endpoint URL or filesystem path."
+        assert emitted.context is True
+        assert emitted.strict_validation is False
+        assert emitted.default == 1000
 
     def test_strict_spec_emits_allowed_values_unchanged(self) -> None:
         """``allowed_values`` passes through by reference so doc-dicts survive intact."""
         allowed = {"a": "Doc for a.", "b": "Doc for b."}
         emitted = property_spec("A strict enum.", strict=True, allowed_values=allowed, default="a")
-        assert emitted["allowed_values"] is allowed
-        assert emitted[DefaultOptionKeys.strict_validation] is True
-        assert emitted[DefaultOptionKeys.default] == "a"
+        assert emitted.allowed_values is allowed
+        assert emitted.strict_validation is True
+        assert emitted.default == "a"
 
     def test_omitted_default_emits_none(self) -> None:
-        """The wrapper always emits ``default`` (explicit ``None``); core omits it when None."""
+        """The wrapper defaults to ``default=None`` (optional); core defaults to required."""
         emitted = property_spec("An optional key.")
-        assert emitted[DefaultOptionKeys.default] is None
+        assert emitted.default is None
 
 
 class TestPropertySpecInvariants:
@@ -55,30 +52,28 @@ class TestPropertySpecInvariants:
         with pytest.raises(ValueError, match="never enforced"):
             property_spec("Decorative enum.", allowed_values={"a": "Doc."})
 
-        assert _core_property_spec("Decorative enum.", allowed_values={"a": "Doc."})[
-            DefaultOptionKeys.allowed_values
-        ] == {"a": "Doc."}
+        assert _core_property_spec("Decorative enum.", allowed_values={"a": "Doc."}).allowed_values == {"a": "Doc."}
 
     def test_strict_default_outside_allowed_set_rejected(self) -> None:
-        with pytest.raises(ValueError, match="declares default"):
+        with pytest.raises(ValueError, match="not within the declared allowed_values"):
             property_spec("Bad default.", strict=True, allowed_values={"a": "Doc."}, default="z")
 
     def test_strict_none_default_permitted(self) -> None:
         """A strict enum may leave ``default=None``; an absent key is simply not validated."""
         emitted = property_spec("Strict, no default.", strict=True, allowed_values={"a": "Doc."})
-        assert emitted[DefaultOptionKeys.default] is None
+        assert emitted.default is None
 
     def test_iterable_allowed_values_accepted(self) -> None:
         """Plain iterables mirror ``spec_allowed_values``; the default check still applies."""
         emitted = property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="b")
-        assert emitted["allowed_values"] == ("a", "b")
-        with pytest.raises(ValueError, match="declares default"):
+        assert emitted.allowed_values == ("a", "b")
+        with pytest.raises(ValueError, match="not within the declared allowed_values"):
             property_spec("Tuple enum.", strict=True, allowed_values=("a", "b"), default="z")
 
     def test_generator_allowed_values_materialized(self) -> None:
         """A one-shot iterable is materialized, not emitted exhausted."""
         emitted = property_spec("Generator enum.", strict=True, allowed_values=(v for v in ("a", "b")), default="a")
-        assert emitted["allowed_values"] == ("a", "b")
+        assert emitted.allowed_values == ("a", "b")
         no_values: tuple[str, ...] = ()
         with pytest.raises(ValueError, match="empty allowed_values would reject"):
             property_spec("Empty generator.", strict=True, allowed_values=(v for v in no_values))

--- a/open_kgo/feature_groups/kg/tests/test_validate_params_collect_all.py
+++ b/open_kgo/feature_groups/kg/tests/test_validate_params_collect_all.py
@@ -21,10 +21,9 @@ from typing import Any, ClassVar
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
-
 from open_kgo.feature_groups.kg.base import ParamReader
 from open_kgo.feature_groups.kg.errors import MissingRequiredParamsError
+from open_kgo.feature_groups.kg.spec import property_spec
 from open_kgo.feature_groups.kg.tests._discovery import clean_kg_subclass_registry
 
 _CONNECTOR_ID = "_test_multi_group_param_reader"
@@ -40,9 +39,9 @@ def _build_multi_group_reader() -> type[ParamReader]:
     class _MultiGroupParamReader(ParamReader):
         CONNECTOR_ID: ClassVar[str] = _CONNECTOR_ID
         PARAMS_MAPPING: ClassVar[dict[str, Any]] = {
-            "alpha": {DefaultOptionKeys.context: True, DefaultOptionKeys.strict_validation: False},
-            "bravo": {DefaultOptionKeys.context: True, DefaultOptionKeys.strict_validation: False},
-            "charlie": {DefaultOptionKeys.context: True, DefaultOptionKeys.strict_validation: False},
+            "alpha": property_spec("alpha"),
+            "bravo": property_spec("bravo"),
+            "charlie": property_spec("charlie"),
         }
         REQUIRED_PARAMS: ClassVar[tuple[tuple[str, ...], ...]] = (
             ("alpha",),

--- a/open_kgo/feature_groups/kg/tests/test_validation_contract.py
+++ b/open_kgo/feature_groups/kg/tests/test_validation_contract.py
@@ -111,8 +111,8 @@ def test_nonstrict_specs_declare_no_allowed_values() -> None:
             )
 
 
-def test_spec_allowed_values_ignores_doc_only_keys() -> None:
-    """Adding an unrelated string key to a spec must not affect the allowed set."""
+def test_spec_allowed_values_dict_form_reduces_to_keys() -> None:
+    """A dict-form ``allowed_values`` (value to docstring) reduces to its keys, not its values."""
     spec = _core_property_spec("Probe enum.", strict=True, allowed_values={"a": "A", "b": "B"})
     allowed = KgConnectorReaderBase._spec_allowed_values("mode", spec)
     assert allowed == {"a", "b"}

--- a/open_kgo/feature_groups/kg/tests/test_validation_contract.py
+++ b/open_kgo/feature_groups/kg/tests/test_validation_contract.py
@@ -8,15 +8,14 @@ rather than under each family.
 from __future__ import annotations
 
 import warnings
-from typing import Any
 
 import pytest
 
-from mloda.core.abstract_plugins.components.default_options_key import DefaultOptionKeys
 from mloda.core.abstract_plugins.components.feature import Feature
 from mloda.core.abstract_plugins.components.feature_set import FeatureSet
 from mloda.core.abstract_plugins.components.options import Options
 from mloda.provider import HashableDict
+from mloda.provider import property_spec as _core_property_spec
 
 from open_kgo.feature_groups.kg.base import (
     KgConnectorReaderBase,
@@ -93,7 +92,7 @@ def test_strict_specs_declare_allowed_values_explicitly() -> None:
     """
     for klass in walk_subclasses(KgConnectorReaderBase):
         for key, spec, layer_name in iter_strict_specs(klass):
-            assert "allowed_values" in spec, (
+            assert spec.allowed_values is not None, (
                 f"{klass.__name__}.{layer_name}[{key!r}] has strict_validation=True but no 'allowed_values' field."
             )
 
@@ -106,7 +105,7 @@ def test_nonstrict_specs_declare_no_allowed_values() -> None:
     """
     for klass in walk_subclasses(KgConnectorReaderBase):
         for key, spec, layer_name in iter_nonstrict_specs(klass):
-            assert "allowed_values" not in spec, (
+            assert spec.allowed_values is None, (
                 f"{klass.__name__}.{layer_name}[{key!r}] declares 'allowed_values' without "
                 f"strict_validation=True, so the set is never enforced."
             )
@@ -114,35 +113,27 @@ def test_nonstrict_specs_declare_no_allowed_values() -> None:
 
 def test_spec_allowed_values_ignores_doc_only_keys() -> None:
     """Adding an unrelated string key to a spec must not affect the allowed set."""
-    spec: dict[Any, Any] = {
-        "explanation": "Probe enum.",
-        "allowed_values": {"a": "A", "b": "B"},
-        # Doc-only key that the prior key-derivation logic would have promoted:
-        "see_also": "https://example.invalid/related",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.default: "a",
-    }
+    spec = _core_property_spec("Probe enum.", strict=True, allowed_values={"a": "A", "b": "B"})
     allowed = KgConnectorReaderBase._spec_allowed_values("mode", spec)
     assert allowed == {"a", "b"}
-    assert "see_also" not in allowed
 
 
 def test_spec_allowed_values_raises_when_missing() -> None:
-    """A misconfigured spec (strict=True but no allowed_values) is itself a shape error."""
-    spec: dict[Any, Any] = {
-        "explanation": "Bad spec.",
-        DefaultOptionKeys.context: True,
-        DefaultOptionKeys.strict_validation: True,
-        DefaultOptionKeys.default: "a",
-    }
+    """A misconfigured spec (strict=True but no allowed_values) is itself a shape error.
+
+    ``PropertySpec`` only allows a strict spec with no ``allowed_values`` when
+    an ``element_validator`` takes over as the value space; open-kgo's own
+    ``spec_allowed_values`` does not consult ``element_validator``, so such a
+    spec is still a shape error for the KG credential surface.
+    """
+    spec = _core_property_spec("Bad spec.", strict=True, element_validator=lambda value: True)
     with pytest.raises(InvalidCredentialShape):
         KgConnectorReaderBase._spec_allowed_values("mode", spec)
 
 
 def test_spec_allowed_values_accepts_iterable() -> None:
     """Allowed values may be supplied as a plain list/tuple, not only as a dict."""
-    spec = {"allowed_values": ["x", "y"], DefaultOptionKeys.strict_validation: True}
+    spec = _core_property_spec("Probe enum.", strict=True, allowed_values=["x", "y"])
     assert KgConnectorReaderBase._spec_allowed_values("mode", spec) == {"x", "y"}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,12 @@ exclude-newer-package = { mloda = "0 days", "mloda-testing" = "0 days", "mloda-r
 # Overrides, not constraints: marimo pins `pymdown-extensions<11`, and the fix for the
 # b64 path-traversal advisory only ships in 11.0. A constraint cannot beat that upper
 # pin, so the pin is overridden here. Drop this once marimo allows 11.x.
-# mloda-testing>=0.4.0 pins `mloda<0.11.0` (not yet updated for the 0.11.0 release);
-# open-kgo only exercises mloda-testing's FeatureGroupTestBase import, verified working
-# against mloda 0.11.0. Drop this once mloda-testing raises its own mloda ceiling.
+# The committed uv.lock stays on mloda-testing 0.3.2 (no upper mloda pin), so this
+# override is inert there; it only matters for a fresh resolution (e.g. tox, which
+# resolves independently of uv.lock) that picks mloda-testing>=0.4.0, which pins
+# `mloda<0.11.0` (not yet updated for the 0.11.0 release). open-kgo only exercises
+# mloda-testing's FeatureGroupTestBase import, verified working against mloda 0.11.0.
+# Drop this once mloda-testing raises its own mloda ceiling.
 override-dependencies = [
     "pymdown-extensions>=11.0.1",
     "mloda>=0.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "open-kgo"
 # semantic-release bumps the latest git tag; needs a `0.2.0` tag pushed once by
-# hand to bootstrap. The mloda floor (>=0.11.0) is unrelated.
+# hand to bootstrap. The mloda floor (>=0.11.0,<0.12.0) is unrelated.
 version = "0.3.1"
 description = "Open Knowledge Graphs and Ontologies plugin for mloda."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "tomkaltofen@mloda.ai" }]
-dependencies = ["mloda>=0.11.0"]
+dependencies = ["mloda>=0.11.0,<0.12.0"]
 requires-python = ">=3.10"
 # No `License ::` trove classifier: `license` above is an SPDX expression
 # (PEP 639) and setuptools rejects both together.
@@ -115,13 +115,7 @@ exclude-newer-package = { mloda = "0 days", "mloda-testing" = "0 days", "mloda-r
 # Overrides, not constraints: marimo pins `pymdown-extensions<11`, and the fix for the
 # b64 path-traversal advisory only ships in 11.0. A constraint cannot beat that upper
 # pin, so the pin is overridden here. Drop this once marimo allows 11.x.
-# The committed uv.lock stays on mloda-testing 0.3.2 (no upper mloda pin), so this
-# override is inert there; it only matters for a fresh resolution (e.g. tox, which
-# resolves independently of uv.lock) that picks mloda-testing>=0.4.0, which pins
-# `mloda<0.11.0` (not yet updated for the 0.11.0 release). open-kgo only exercises
-# mloda-testing's FeatureGroupTestBase import, verified working against mloda 0.11.0.
-# Drop this once mloda-testing raises its own mloda ceiling.
 override-dependencies = [
     "pymdown-extensions>=11.0.1",
-    "mloda>=0.11.0",
+    "mloda>=0.11.0,<0.12.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,13 +5,13 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "open-kgo"
 # semantic-release bumps the latest git tag; needs a `0.2.0` tag pushed once by
-# hand to bootstrap. The mloda floor (>=0.10.0) is unrelated.
+# hand to bootstrap. The mloda floor (>=0.11.0) is unrelated.
 version = "0.3.1"
 description = "Open Knowledge Graphs and Ontologies plugin for mloda."
 readme = "README.md"
 license = "Apache-2.0"
 authors = [{ name = "Tom Kaltofen", email = "tomkaltofen@mloda.ai" }]
-dependencies = ["mloda>=0.10.0"]
+dependencies = ["mloda>=0.11.0"]
 requires-python = ">=3.10"
 # No `License ::` trove classifier: `license` above is an SPDX expression
 # (PEP 639) and setuptools rejects both together.
@@ -111,6 +111,10 @@ exclude-newer-package = { mloda = "0 days", "mloda-testing" = "0 days", "mloda-r
 # Overrides, not constraints: marimo pins `pymdown-extensions<11`, and the fix for the
 # b64 path-traversal advisory only ships in 11.0. A constraint cannot beat that upper
 # pin, so the pin is overridden here. Drop this once marimo allows 11.x.
+# mloda-testing>=0.4.0 pins `mloda<0.11.0` (not yet updated for the 0.11.0 release);
+# open-kgo only exercises mloda-testing's FeatureGroupTestBase import, verified working
+# against mloda 0.11.0. Drop this once mloda-testing raises its own mloda ceiling.
 override-dependencies = [
     "pymdown-extensions>=11.0.1",
+    "mloda>=0.11.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,11 @@ dev = [
     "tox-uv",
     "uv>=0.11.6",
     "pytest",
-    "ruff",
+    # Pinned exactly: tox's default env resolves dependencies independently of
+    # uv.lock (see mloda-ai/open-kgo#66), so an unpinned ruff can silently drift
+    # to a release with different default rules/formatting than what was
+    # actually tested here, turning CI red for reasons unrelated to any change.
+    "ruff==0.15.20",
     "mypy",
     "bandit",
     "mloda-testing>=0.3.2",

--- a/uv.lock
+++ b/uv.lock
@@ -18,7 +18,7 @@ mloda-registry = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
 overrides = [
-    { name = "mloda", specifier = ">=0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "pymdown-extensions", specifier = ">=11.0.1" },
 ]
 
@@ -901,7 +901,7 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'kg-embedded'", specifier = ">=0.11" },
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
-    { name = "mloda", specifier = ">=0.11.0" },
+    { name = "mloda", specifier = ">=0.11.0,<0.12.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'kg-ontology'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'kg-semantic-field'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'kg-rdf'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
     { name = "tox", marker = "extra == 'dev'" },
     { name = "tox-uv", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.11.6" },

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,10 @@ mloda = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 mloda-registry = { timestamp = "0001-01-01T00:00:00Z", span = "PT0S" }
 
 [manifest]
-overrides = [{ name = "pymdown-extensions", specifier = ">=11.0.1" }]
+overrides = [
+    { name = "mloda", specifier = ">=0.11.0" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
+]
 
 [[package]]
 name = "anyio"
@@ -649,10 +652,10 @@ wheels = [
 
 [[package]]
 name = "mloda"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/9d/2251f947bfde5e168b9f6759079c8b54af0393c3e854987268459b860776/mloda-0.10.0-py3-none-any.whl", hash = "sha256:13fd1482566de203cac661c29f5736423ce7d1cc8e43ec26f8d24d19e6386229", size = 456550, upload-time = "2026-07-13T18:35:02.322Z" },
+    { url = "https://files.pythonhosted.org/packages/56/70/f1bb826b6d4fca716a9dcc46a785269eab63a59aa047be52ed82da510a9b/mloda-0.11.0-py3-none-any.whl", hash = "sha256:867834e19723a282df8de5e843e67871703b4113c14f403a0d09dc8b424f5b08", size = 535571, upload-time = "2026-08-17T11:49:27.791Z" },
 ]
 
 [[package]]
@@ -898,7 +901,7 @@ requires-dist = [
     { name = "igraph", marker = "extra == 'kg-embedded'", specifier = ">=0.11" },
     { name = "kuzu", marker = "extra == 'kg-network-pg'", specifier = ">=0.4" },
     { name = "marimo", marker = "extra == 'demo'" },
-    { name = "mloda", specifier = ">=0.10.0" },
+    { name = "mloda", specifier = ">=0.11.0" },
     { name = "mloda-testing", marker = "extra == 'dev'", specifier = ">=0.3.2" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "networkx", marker = "extra == 'kg-embedded'", specifier = ">=3.2" },


### PR DESCRIPTION
## Summary

Bumps the `mloda` floor to 0.11.0 and adapts open-kgo to its breaking change: `PROPERTY_MAPPING`/`PARAMS_MAPPING` values are now `PropertySpec` dataclass instances instead of plain dicts, so a raw dict spec (or a stale `.setdefault(...)` call on the returned builder result) now raises at class definition rather than at first runtime use.

- `open_kgo/feature_groups/kg/spec.py` (open-kgo's thin wrapper over `mloda.provider.property_spec`) no longer post-processes the builder's return value as a dict; it forwards `default` (optional, defaulting to `None`) straight through and returns the `PropertySpec` core builds.
- Every place that read a spec via dict subscripting or `.get(DefaultOptionKeys.X)` (`class_guards.py`, `composition.py`, `credentials.py`, `reader_base.py`, and a long tail of tests that hand-built or inspected specs) moved to attribute access.
- A `PropertySpec` built without a declared default (mloda's `NO_DEFAULT` sentinel, reachable via `mloda.provider.property_spec` used directly rather than through the KG wrapper) now fails loudly at class-definition time instead of leaking the sentinel into credential/diagnostic code that expects a plain value or `None`.
- The KG wrapper's `allowed_values` handling materializes an arbitrary iterable into a tuple for caller convenience, but leaves `str`/`bytes` unmaterialized so core's own typo guard (a bare string would otherwise silently become a per-character value space) still fires.
- The in-process tuple store's `tenant` spec override uses `dataclasses.replace` on the family base's spec rather than reconstructing it from scratch, so it keeps inheriting any field the family base adds later.
- mloda's other 0.11.0 breaking changes (facade re-exports moving under `mloda.user.<backend>`, required-presence on the string-named match path, the smaller removals/tightenings) don't apply here: open-kgo already imports compute frameworks via the unaffected deep import paths and doesn't use name-based (`PREFIX_PATTERN`) feature matching anywhere.
- `pyproject.toml` gained a `mloda>=0.11.0` entry in `[tool.uv] override-dependencies`: `mloda-testing`'s latest release (0.4.x) still pins `mloda<0.11.0` and hasn't caught up to this release yet. open-kgo only exercises one import from `mloda-testing` (`FeatureGroupTestBase`, via a single smoke test), verified working against mloda 0.11.0 before adding the override.

Heads-up for downstream open-kgo plugin authors: a `PROPERTY_MAPPING` written as a raw dict literal (rather than through `property_spec(...)`) now raises an import-time error instead of working. This ships as a `chore(deps):` patch bump per this repo's semantic-release config, so it won't show up as a major version bump; flagging it here since it's a real behavior change for anyone extending `KgConnectorReaderBase` directly.

## Test plan

- [x] `pytest` (1049 passed, 56 skipped)
- [x] `ruff format --check --line-length 120 .`
- [x] `ruff check .`
- [x] `mypy --strict --ignore-missing-imports .`
- [x] `bandit -c pyproject.toml -r -q .`