### PR TITLE
fix: reuse uv.lock for tox's default env instead of resolving fresh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          # Pinned: a uv minor bump can change lockfile serialization.
+          python -m pip install "uv>=0.12,<0.13"
           uv tool install tox --with tox-uv
 
       - name: Run tox
@@ -58,7 +59,8 @@ jobs:
       - name: Install tox
         run: |
           python -m pip install --upgrade pip
-          python -m pip install uv
+          # Pinned: a uv minor bump can change lockfile serialization.
+          python -m pip install "uv>=0.12,<0.13"
           uv tool install tox --with tox-uv
 
       - name: Run notebook tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,11 +42,7 @@ dev = [
     "tox-uv",
     "uv>=0.11.6",
     "pytest",
-    # Pinned exactly: tox's default env resolves dependencies independently of
-    # uv.lock (see mloda-ai/open-kgo#66), so an unpinned ruff can silently drift
-    # to a release with different default rules/formatting than what was
-    # actually tested here, turning CI red for reasons unrelated to any change.
-    "ruff==0.15.20",
+    "ruff",
     "mypy",
     "bandit",
     "mloda-testing>=0.3.2",

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,9 @@
 envlist = python310
 
 [testenv]
-usedevelop = true
+# Installs from the committed uv.lock so the gate is reproducible per commit
+# (mloda-ai/open-kgo#66).
+runner = uv-venv-lock-runner
 extras =
     dev
     kg-all
@@ -19,7 +21,6 @@ commands =
 # Kept out of the default env so local `tox` stays fast; CI runs this as a
 # separate `tox -e notebooks` job (see .github/workflows/test.yml). The
 # `demo` extra pulls in marimo (and kg-all, which the notebooks exercise).
-usedevelop = true
 extras =
     dev
     kg-all
@@ -29,7 +30,9 @@ commands =
     pytest -m notebooks
 
 [testenv:security]
-# CVE scanning environment - builds and scans the local package
+# CVE scanning environment - builds and scans the local package. Resolves
+# fresh (not the lock runner) to catch CVEs newer than uv.lock's pins.
+runner = uv-venv-runner
 usedevelop = true
 extras = dev
 deps =

--- a/uv.lock
+++ b/uv.lock
@@ -914,7 +914,7 @@ requires-dist = [
     { name = "pyyaml", marker = "extra == 'kg-ontology'", specifier = ">=6.0" },
     { name = "pyyaml", marker = "extra == 'kg-semantic-field'", specifier = ">=6.0" },
     { name = "rdflib", marker = "extra == 'kg-rdf'", specifier = ">=7.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.20" },
+    { name = "ruff", marker = "extra == 'dev'" },
     { name = "tox", marker = "extra == 'dev'" },
     { name = "tox-uv", marker = "extra == 'dev'" },
     { name = "uv", marker = "extra == 'dev'", specifier = ">=0.11.6" },


### PR DESCRIPTION
tox'''s default env resolved dev tool dependencies independently of the committed `uv.lock`, so an unpinned tool could drift to a newer release than the repo was tested against and break CI unrelated to any code change.

Closes #66

- `tox.ini`: default env now uses tox-uv'''s `uv-venv-lock-runner`, installing from `uv.lock` instead of resolving fresh. `security` env keeps fresh resolution (CVE scanning wants newer versions than what'''s locked).
- Drop the one-off `ruff==0.15.20` pin now that the lock is the source of truth; refresh `uv.lock` to match.
- Pin `uv` in CI, since the gate now depends on it reading the lockfile consistently.
