### PR TITLE
chore(ci): let Dependabot watch the GitHub Actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Workflows live in .github/workflows, but Dependabot expects "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Closes #72

`.github/dependabot.yml` only declared the `uv` ecosystem, so the actions pinned across the two workflows never received update PRs.

Confirmed which pins were going unwatched:

```
$ grep -h -o 'uses: [^ ]*' .github/workflows/*.yml .github/workflows/*.yaml | sort -u
uses: actions/checkout@v4
uses: actions/setup-node@v4
uses: actions/setup-python@v5
uses: astral-sh/setup-uv@v7
```

The new entry mirrors the existing `uv` one, `all-dependencies` grouping included, so action bumps land as one PR rather than one per action.

One thing worth flagging since it looks like a mistake on review: `directory: "/"` is correct even though the workflows live under `.github/workflows`. For the `github-actions` ecosystem Dependabot resolves that location itself, and the more intuitive `".github/workflows"` is rejected as an invalid directory. I left a comment on the line so the next reader doesn't 'fix' it.

Validated:

```
$ python -c "import yaml,pathlib; d=yaml.safe_load(pathlib.Path('.github/dependabot.yml').read_text()); print([u['package-ecosystem'] for u in d['updates']])"
['uv', 'github-actions']
```