### PR TITLE
docs: correct the demo notebook and eval harness counts in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Interactive demo: `marimo edit demo/demo_discovery.py`
 
 ## Demos
 
-Three marimo notebooks plus two evaluation harnesses live under `demo/`:
+Five marimo notebooks plus three evaluation harnesses live under `demo/`:
 
 - `demo/demo_kg_connectors.py`: surface tour of all 9 families against the shipped fixtures.
 - `demo/demo_kg_build_repo.py`: builds an RDF graph from this repo (filesystem `repo:contains` + Python `repo:imports`), serializes to Turtle, and runs five SPARQL queries through `RdfLibSparqlReader` via `mloda.run_all`.
@@ -212,7 +212,7 @@ Three marimo notebooks plus two evaluation harnesses live under `demo/`:
 - `demo/demo_semantic_field.py`: SemanticField Layer 2 — interactive director + genre query against MetaQA, with live scoring.
 - `demo/demo_discovery.py`: DiscoveryEngine Layer 3 — beam search over the EM field, find_paths and extract_circuit against the sample graph.
 - `demo/semantic_field_explainer.html`: full visual explainer for SemanticField — circuit diagram, layer stack, why EM, 1/2/multi-hop examples, test results. Open in any browser.
-- `demo/eval_arch1_vs_arch2.py` and `demo/eval_qa_accuracy.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal.
+- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; both share the setup and scoring loop in `demo/qa_eval_lib.py`.
 
 Install the demo extras and open any notebook:
 


### PR DESCRIPTION
Closes #73

The `## Demos` intro said *"Three marimo notebooks plus two evaluation harnesses"* while the bullet list directly beneath it already named five `demo_*.py` notebooks, and `eval_qa_accuracy_2hop.py` appeared nowhere in the list.

Counted from the tree rather than trusting either the prose or the list:

```
demo_* notebooks:  5  ['demo_discovery.py', 'demo_kg_build_repo.py', 'demo_kg_connectors.py', 'demo_kg_ontology.py', 'demo_semantic_field.py']
eval_* harnesses:  3  ['eval_arch1_vs_arch2.py', 'eval_qa_accuracy.py', 'eval_qa_accuracy_2hop.py']
files containing 'import marimo': 8
```

`eval_qa_accuracy_2hop.py` is not a stray file — it opens with `import marimo` like the rest, `tests/test_demo_notebooks.py` already globs it in, and `demo/qa_eval_lib.py`'s module docstring already refers to *"The three eval notebooks"*. The README was the only thing out of date.

I also gave the eval bullet enough detail to tell the two accuracy harnesses apart — "comparing plain traversal vs. ontology-guided traversal" describes both equally, so the 1-hop / 2-hop split is what a reader actually needs to choose between them.

`python -m pytest tests/test_demo_notebooks.py` → 1 skipped (the demo extras aren't installed here, so the notebook execution test self-skips; it is unaffected by a docs change either way).