### PR TITLE
docs: link the GitHub workflows page from the README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ tox
 
 It runs pytest, `ruff format --check`, `ruff check`, `mypy --strict`, and bandit.
 
+The same checks run on your PR through the test workflow; see
+[docs/github-workflows.md](docs/github-workflows.md) for what CI does with them
+and how releases are cut.
+
 ## Ground rules
 
 - **Tests required.** Every feature or fix ships with tests — follow the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 | [Demos](#demos) | Marimo notebooks and evaluation harnesses, all offline |
 | [Data and acknowledgments](#data-and-acknowledgments) | Where the sample data comes from |
 | [Development setup](#development-setup) | uv, tox, and the individual checks |
+| [GitHub workflows](docs/github-workflows.md) | What CI runs on a PR, and how releases are cut |
 | [Related repositories and documentation](#related-repositories-and-documentation) | mloda core, the plugin registry, and development guides |
 
 ## Quickstart
@@ -273,3 +274,4 @@ bandit -c pyproject.toml -r -q .
 - **[mloda-registry](https://github.com/mloda-ai/mloda-registry)**: The central hub for discovering and sharing mloda plugins.
 - **[Plugin development guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides/)**: How to build FeatureGroups, ComputeFrameworks, and Extenders.
 - **[Claude Code skills](https://github.com/mloda-ai/mloda-registry/tree/main/.claude/skills/)**: Assisted plugin development for Claude Code users.
+- **[GitHub workflows](docs/github-workflows.md)**: What the test and release workflows in this repo do, and the two secrets a maintainer needs to set up for a release.


### PR DESCRIPTION
Closes #74

`docs/github-workflows.md` was orphaned — nothing in `README.md`, `CONTRIBUTING.md`, `AGENTS.md` or `CLAUDE.md` linked to it:

```
$ grep -rn 'github-workflows' --include=*.md .
(no output)
```

Since `docs/` contains only that one file, browsing the directory was the only way to find it.

Linked from three places rather than one, each chosen so the link answers a question the reader already has at that point:

- **README "At a glance"**, as a row directly under *Development setup* — "what CI runs on a PR" is the natural follow-on to "how do I run the checks locally".
- **README "Related repositories and documentation"**, which is where the other guides already live.
- **CONTRIBUTING "Before you open a PR"**, immediately after the line listing what `tox` runs, since that is the paragraph that prompts the question.

The issue asked for the README link and called CONTRIBUTING optional; I included it because that section is where the workflows are most relevant, but happy to drop it if you'd rather keep the pointer in one place.

Link targets verified to resolve to a real file rather than eyeballed — all three resolve to `docs/github-workflows.md`, which exists.