### PR TITLE
test: cover load_kb's blank and malformed line skips

### DIFF
--- a/tests/test_metaqa_build_sample.py
+++ b/tests/test_metaqa_build_sample.py
@@ -20,6 +20,33 @@ def test_load_kb_parses_pipe_separated_triples() -> None:
     assert {"directed_by", "starred_actors", "has_genre"} <= relations
 
 
+def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
+    """Blank and not-exactly-3-field lines are skipped, not parsed and not raised on.
+
+    Written to a tmp_path file rather than the shared tiny_kb.txt fixture so the
+    other tests reading that fixture keep their exact expected edge set.
+    """
+    kb = tmp_path / "messy_kb.txt"
+    kb.write_text(
+        "\n".join(
+            [
+                "Movie1|directed_by|Director1",
+                "",  # blank
+                "   ",  # whitespace only, blank after strip()
+                "Movie1|directed_by",  # 2 fields
+                "Movie1|directed_by|Director1|extra",  # 4 fields
+                "Movie1",  # 1 field, no separator at all
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    g = build_sample.load_kb(kb)
+
+    assert list(g.edges(data="relation")) == [("Movie1", "Director1", "directed_by")]
+
+
 def test_read_topic_entities_extracts_brackets() -> None:
     topics = build_sample.read_topic_entities([TINY_QA])
     assert topics == {"Movie1", "Movie2"}


### PR DESCRIPTION
Closes #75

`load_kb` skips blank lines and lines that don't split into exactly three pipe-separated fields, but neither `continue` was reachable from any test — `tests/fixtures/data/tiny_kb.txt` is all well-formed 3-field lines with no blanks. Nothing would have failed if "skip and carry on" silently became "raise".

The new test writes its own KB via `tmp_path` instead of editing the shared fixture, so the other tests reading `tiny_kb.txt` keep their exact expected edge set. Five inputs alongside one valid triple:

| line | why |
|---|---|
| `""` | empty |
| `"   "` | blank only after `strip()` — a different branch from the above at the source level |
| `Movie1\|directed_by` | 2 fields |
| `Movie1\|directed_by\|Director1\|extra` | 4 fields |
| `Movie1` | no separator at all |

One equality assertion on `g.edges(data="relation")` covers both directions — the valid triple survived, **and** nothing else was created. An `in`-style assertion would only have checked the first.

Verified the test isn't vacuous by mutating the guard from `!= 3` to `< 3`:

```
FAILED tests/test_metaqa_build_sample.py::test_load_kb_skips_blank_and_malformed_lines
1 failed, 6 passed
```

Restored, full file green: `7 passed in 0.80s`.