### PR TITLE
test: cover the edges operation and graphml format for NetworkxEmbeddedReader

### DIFF
--- a/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
@@ -18,6 +18,21 @@ from open_kgo.feature_groups.kg.tests._helpers import make_valid_credentials
 
 
 _FIXTURE_GML = Path(__file__).parent / "fixtures" / "triangle.gml"
+_FIXTURE_DIRECTED_GML = Path(__file__).parent / "fixtures" / "directed_chain.gml"
+
+# Same document the igraph sibling uses, so a difference between the two
+# backends cannot be blamed on the input.
+_GRAPHML_CHAIN = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <graph id="G" edgedefault="directed">
+    <node id="alice"/>
+    <node id="bob"/>
+    <node id="carol"/>
+    <edge source="alice" target="bob"/>
+    <edge source="bob" target="carol"/>
+  </graph>
+</graphml>
+"""
 
 
 class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
@@ -58,3 +73,32 @@ class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
         )
         rows = run_query("networkx_embedded", self.valid_credentials()["networkx_embedded"], feat)
         assert sorted(r["node"] for r in rows) == ["bob", "carol"]
+
+    def test_edges_operation(self) -> None:
+        """``operation=edges`` is advertised in SUPPORTED_VALUES and dispatched in _load_rows, but was never asserted."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = {"locator": str(_FIXTURE_DIRECTED_GML), "graph_file_format": "gml"}
+        feat = Feature("networkx_embedded__edges", options=Options(context={"operation": "edges"}))
+        rows = run_query("networkx_embedded", slot, feat)
+        assert sorted((r["src"], r["dst"]) for r in rows) == [("alice", "bob"), ("bob", "carol")]
+
+    def test_graphml_format_loads_and_returns_rows(self, tmp_path: Path) -> None:
+        """``graph_file_format=graphml`` maps to nx.read_graphml in _LOADERS; prove that path works.
+
+        Asserts nodes and edges from one tmp_path-written GraphML document, so
+        the advertised format is exercised end to end rather than only declared.
+        """
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        graphml_path = tmp_path / "chain.graphml"
+        graphml_path.write_text(_GRAPHML_CHAIN, encoding="utf-8")
+        slot = {"locator": str(graphml_path), "graph_file_format": "graphml"}
+
+        nodes_feat = Feature("networkx_embedded__graphml_nodes", options=Options(context={"operation": "nodes"}))
+        node_rows = run_query("networkx_embedded", slot, nodes_feat)
+        assert sorted(r["node"] for r in node_rows) == ["alice", "bob", "carol"]
+
+        edges_feat = Feature("networkx_embedded__graphml_edges", options=Options(context={"operation": "edges"}))
+        edge_rows = run_query("networkx_embedded", slot, edges_feat)
+        assert sorted((r["src"], r["dst"]) for r in edge_rows) == [("alice", "bob"), ("bob", "carol")]


### PR DESCRIPTION
Closes #76

`NetworkxEmbeddedReader.SUPPORTED_VALUES` advertises the same `operation` and `graph_file_format` values as `IGraphEmbeddedReader`, but `test_networkx_embedded.py` had exactly one connector-specific test (`test_neighbors_operation`). `operation=edges` was dispatched in `_load_rows` and `graphml` was wired into `_LOADERS` as `nx.read_graphml` — both **declared but never proven**.

The two new methods mirror `test_igraph_embedded.py`'s `test_directed_edges_operation` and `test_graphml_format_loads_and_returns_rows`.

**No new fixtures.** The GML case reuses the committed `directed_chain.gml`, and the GraphML document is the same literal the igraph test uses — deliberately, so that if the two backends ever disagree on these paths, the input is ruled out as the cause and the difference has to be in the reader.

As the issue suggested, I did **not** duplicate the igraph/networkx parity assertion — that already lives on the igraph side.

Verified:

```
$ pytest open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
29 passed, 4 skipped in 0.63s

$ pytest ... -k "edges_operation or graphml_format"
2 passed, 31 deselected

$ ruff format --check   ->  1 file already formatted
$ ruff check            ->  All checks passed!
$ mypy --strict         ->  Success: no issues found in 1 source file
```