### PR TITLE
chore(ci): let Dependabot watch the GitHub Actions ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Workflows live in .github/workflows, but Dependabot expects "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
Cherry-pick of #77's commit (unmodified, same author) onto a fresh branch off main so it can be reviewed and merged directly. Closes #72, related: #77.

Reviewed via a thorough automated pass (correctness, reuse, cross-file, CLAUDE.md conventions); no defects that block this PR on its own. One follow-up gap it surfaced (missing Dependabot `cooldown` for parity with this repo's supply-chain buffering philosophy) is addressed in a separate PR, since it applies review fixes across a few of these cherry-picks: see the fix PR based on `base/review-fixes-77-78-80`.