### PR TITLE
docs: link the GitHub workflows page from the README and CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ tox
 
 It runs pytest, `ruff format --check`, `ruff check`, `mypy --strict`, and bandit.
 
+The same checks run on your PR through the test workflow; see
+[docs/github-workflows.md](docs/github-workflows.md) for what CI does with them
+and how releases are cut.
+
 ## Ground rules
 
 - **Tests required.** Every feature or fix ships with tests — follow the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 | [Demos](#demos) | Marimo notebooks and evaluation harnesses, all offline |
 | [Data and acknowledgments](#data-and-acknowledgments) | Where the sample data comes from |
 | [Development setup](#development-setup) | uv, tox, and the individual checks |
+| [GitHub workflows](docs/github-workflows.md) | What CI runs on a PR, and how releases are cut |
 | [Related repositories and documentation](#related-repositories-and-documentation) | mloda core, the plugin registry, and development guides |
 
 ## Quickstart
@@ -273,3 +274,4 @@ bandit -c pyproject.toml -r -q .
 - **[mloda-registry](https://github.com/mloda-ai/mloda-registry)**: The central hub for discovering and sharing mloda plugins.
 - **[Plugin development guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides/)**: How to build FeatureGroups, ComputeFrameworks, and Extenders.
 - **[Claude Code skills](https://github.com/mloda-ai/mloda-registry/tree/main/.claude/skills/)**: Assisted plugin development for Claude Code users.
+- **[GitHub workflows](docs/github-workflows.md)**: What the test and release workflows in this repo do, and the two secrets a maintainer needs to set up for a release.


### PR DESCRIPTION
Cherry-pick of #79's commit (unmodified, same author) onto a fresh branch off main so it can be reviewed and merged directly. Closes #74, related: #79.

Reviewed via a thorough automated pass: verified both new links resolve, cross-checked the README and CONTRIBUTING claims against the actual content of docs/github-workflows.md (checks it lists, the two release secrets), and checked for CLAUDE.md convention violations. No defects found; clean as-is.