### PR TITLE
test: cover the edges operation and graphml format for NetworkxEmbeddedReader

### DIFF
--- a/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
@@ -18,6 +18,21 @@ from open_kgo.feature_groups.kg.tests._helpers import make_valid_credentials
 
 
 _FIXTURE_GML = Path(__file__).parent / "fixtures" / "triangle.gml"
+_FIXTURE_DIRECTED_GML = Path(__file__).parent / "fixtures" / "directed_chain.gml"
+
+# Same document the igraph sibling uses, so a difference between the two
+# backends cannot be blamed on the input.
+_GRAPHML_CHAIN = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <graph id="G" edgedefault="directed">
+    <node id="alice"/>
+    <node id="bob"/>
+    <node id="carol"/>
+    <edge source="alice" target="bob"/>
+    <edge source="bob" target="carol"/>
+  </graph>
+</graphml>
+"""
 
 
 class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
@@ -58,3 +73,32 @@ class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
         )
         rows = run_query("networkx_embedded", self.valid_credentials()["networkx_embedded"], feat)
         assert sorted(r["node"] for r in rows) == ["bob", "carol"]
+
+    def test_edges_operation(self) -> None:
+        """``operation=edges`` is advertised in SUPPORTED_VALUES and dispatched in _load_rows, but was never asserted."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = {"locator": str(_FIXTURE_DIRECTED_GML), "graph_file_format": "gml"}
+        feat = Feature("networkx_embedded__edges", options=Options(context={"operation": "edges"}))
+        rows = run_query("networkx_embedded", slot, feat)
+        assert sorted((r["src"], r["dst"]) for r in rows) == [("alice", "bob"), ("bob", "carol")]
+
+    def test_graphml_format_loads_and_returns_rows(self, tmp_path: Path) -> None:
+        """``graph_file_format=graphml`` maps to nx.read_graphml in _LOADERS; prove that path works.
+
+        Asserts nodes and edges from one tmp_path-written GraphML document, so
+        the advertised format is exercised end to end rather than only declared.
+        """
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        graphml_path = tmp_path / "chain.graphml"
+        graphml_path.write_text(_GRAPHML_CHAIN, encoding="utf-8")
+        slot = {"locator": str(graphml_path), "graph_file_format": "graphml"}
+
+        nodes_feat = Feature("networkx_embedded__graphml_nodes", options=Options(context={"operation": "nodes"}))
+        node_rows = run_query("networkx_embedded", slot, nodes_feat)
+        assert sorted(r["node"] for r in node_rows) == ["alice", "bob", "carol"]
+
+        edges_feat = Feature("networkx_embedded__graphml_edges", options=Options(context={"operation": "edges"}))
+        edge_rows = run_query("networkx_embedded", slot, edges_feat)
+        assert sorted((r["src"], r["dst"]) for r in edge_rows) == [("alice", "bob"), ("bob", "carol")]


### PR DESCRIPTION
Cherry-pick of #81's commit (unmodified, same author) onto a fresh branch off main so it can be reviewed and merged directly. Closes #76, related: #81.

Reviewed via a thorough automated pass, including two independent gap-sweep passes, running the new tests standalone in an isolated worktree, and checking networkx GML/GraphML semantics empirically against the installed version. Confirmed the shared `_GRAPHML_CHAIN` duplication with the igraph sibling test is deliberate and issue-sanctioned (#76), not an oversight. No defects found; clean as-is.