### PR TITLE
fix: address review findings on the #77/#78/#80 cherry-picks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     directory: "/" # Workflows live in .github/workflows, but Dependabot expects "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Five marimo notebooks plus three evaluation harnesses live under `demo/`:
 - `demo/demo_semantic_field.py`: SemanticField Layer 2 — interactive director + genre query against MetaQA, with live scoring.
 - `demo/demo_discovery.py`: DiscoveryEngine Layer 3 — beam search over the EM field, find_paths and extract_circuit against the sample graph.
 - `demo/semantic_field_explainer.html`: full visual explainer for SemanticField — circuit diagram, layer stack, why EM, 1/2/multi-hop examples, test results. Open in any browser.
-- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; both share the setup and scoring loop in `demo/qa_eval_lib.py`.
+- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal, all three sharing setup and hop primitives from `demo/qa_eval_lib.py`. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; only those two also share the scoring loop.
 
 Install the demo extras and open any notebook:
 
@@ -226,7 +226,7 @@ no network, no external services.
 
 ## Data and acknowledgments
 
-The ontology demo and the two evaluation harnesses run against a small
+The ontology demo and the three evaluation harnesses run against a small
 hand-authored sample of public movie facts (`demo/data/sample_kb.txt`) written
 in the triple format of the MetaQA dataset (Zhang, Yuyu et al., "Variational
 Reasoning for Question Answering with Knowledge Graph", AAAI 2018,

--- a/tests/test_metaqa_build_sample.py
+++ b/tests/test_metaqa_build_sample.py
@@ -23,8 +23,11 @@ def test_load_kb_parses_pipe_separated_triples() -> None:
 def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
     """Blank and not-exactly-3-field lines are skipped, not parsed and not raised on.
 
-    Written to a tmp_path file rather than the shared tiny_kb.txt fixture so the
-    other tests reading that fixture keep their exact expected edge set.
+    Written to a tmp_path file rather than the shared tiny_kb.txt fixture to keep
+    these malformed-line cases local to this test. load_kb skips them regardless
+    of which file they live in, so appending them to tiny_kb.txt would not have
+    changed any other test's parsed edge set; a dedicated file is fixture hygiene,
+    not a correctness requirement.
     """
     kb = tmp_path / "messy_kb.txt"
     kb.write_text(
@@ -45,6 +48,7 @@ def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
     g = build_sample.load_kb(kb)
 
     assert list(g.edges(data="relation")) == [("Movie1", "Director1", "directed_by")]
+    assert g.number_of_nodes() == 2
 
 
 def test_read_topic_entities_extracts_brackets() -> None:


### PR DESCRIPTION
This is the 6th PR of the batch: pure review fallout from cherry-picking and reviewing dchaudhari7177's #77, #78, #79, #80, #81 (mirrored here as #83-#87). #79 and #81 came back clean; this PR is the fix commit for the three that didn't.

Base branch (`base/review-fixes-77-78-80`) is a private integration ref carrying just the cherry-picks of #77/#78/#80, so this PR's diff is only the fixes, in the context of the code they fix. It has no PR of its own and isn't meant to be merged as-is; merge order is #83, #84, #86 first, then rebase this fix onto main.

**`.github/dependabot.yml`** (#77 / #83): the new `github-actions` entry had no `cooldown`, unlike this project's documented supply-chain buffering philosophy (`pyproject.toml`'s 7-day `uv` `exclude-newer`). Added a matching `cooldown.default-days: 7`.

**`README.md`** (#78 / #84): the Demos section fix left an identical stale count two paragraphs later ("the two evaluation harnesses"), self-contradicting the "three" just introduced above it. Also tightened the eval-harnesses bullet so it doesn't imply `eval_arch1_vs_arch2.py` shares nothing with `qa_eval_lib.py`: it shares setup and hop primitives with the other two notebooks, just not their QA scoring loop.

**`tests/test_metaqa_build_sample.py`** (#80 / #86): the new test's docstring gave the wrong reason for using `tmp_path` (`tiny_kb.txt`'s edge set would in fact be unaffected either way, since `load_kb` skips malformed lines regardless of file); corrected to fixture hygiene. Also asserts `number_of_nodes()` alongside the edges check, so a future regression that creates a node before the field-count guard would be caught.

`tox` passes on this branch (1045 passed, 57 skipped; ruff format/check, mypy --strict, bandit all clean).