### PR TITLE
chore: cherry-pick dchaudhari7177's #77-#81 batch, with review fixes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,11 @@ updates:
       all-dependencies:
         patterns:
           - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/" # Workflows live in .github/workflows, but Dependabot expects "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     directory: "/" # Workflows live in .github/workflows, but Dependabot expects "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       all-dependencies:
         patterns:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,10 @@ tox
 
 It runs pytest, `ruff format --check`, `ruff check`, `mypy --strict`, and bandit.
 
+The same checks run on your PR through the test workflow; see
+[docs/github-workflows.md](docs/github-workflows.md) for what CI does with them
+and how releases are cut.
+
 ## Ground rules
 
 - **Tests required.** Every feature or fix ships with tests — follow the

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Open Knowledge Graphs and Ontologies plugin for [mloda](https://github.com/mloda
 | [Demos](#demos) | Marimo notebooks and evaluation harnesses, all offline |
 | [Data and acknowledgments](#data-and-acknowledgments) | Where the sample data comes from |
 | [Development setup](#development-setup) | uv, tox, and the individual checks |
+| [GitHub workflows](docs/github-workflows.md) | What CI runs on a PR, and how releases are cut |
 | [Related repositories and documentation](#related-repositories-and-documentation) | mloda core, the plugin registry, and development guides |
 
 ## Quickstart
@@ -273,3 +274,4 @@ bandit -c pyproject.toml -r -q .
 - **[mloda-registry](https://github.com/mloda-ai/mloda-registry)**: The central hub for discovering and sharing mloda plugins.
 - **[Plugin development guides](https://github.com/mloda-ai/mloda-registry/tree/main/docs/guides/)**: How to build FeatureGroups, ComputeFrameworks, and Extenders.
 - **[Claude Code skills](https://github.com/mloda-ai/mloda-registry/tree/main/.claude/skills/)**: Assisted plugin development for Claude Code users.
+- **[GitHub workflows](docs/github-workflows.md)**: What the test and release workflows in this repo do, and the two secrets a maintainer needs to set up for a release.

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Interactive demo: `marimo edit demo/demo_discovery.py`
 
 ## Demos
 
-Three marimo notebooks plus two evaluation harnesses live under `demo/`:
+Five marimo notebooks plus three evaluation harnesses live under `demo/`:
 
 - `demo/demo_kg_connectors.py`: surface tour of all 9 families against the shipped fixtures.
 - `demo/demo_kg_build_repo.py`: builds an RDF graph from this repo (filesystem `repo:contains` + Python `repo:imports`), serializes to Turtle, and runs five SPARQL queries through `RdfLibSparqlReader` via `mloda.run_all`.
@@ -212,7 +212,7 @@ Three marimo notebooks plus two evaluation harnesses live under `demo/`:
 - `demo/demo_semantic_field.py`: SemanticField Layer 2 — interactive director + genre query against MetaQA, with live scoring.
 - `demo/demo_discovery.py`: DiscoveryEngine Layer 3 — beam search over the EM field, find_paths and extract_circuit against the sample graph.
 - `demo/semantic_field_explainer.html`: full visual explainer for SemanticField — circuit diagram, layer stack, why EM, 1/2/multi-hop examples, test results. Open in any browser.
-- `demo/eval_arch1_vs_arch2.py` and `demo/eval_qa_accuracy.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal.
+- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; both share the setup and scoring loop in `demo/qa_eval_lib.py`.
 
 Install the demo extras and open any notebook:
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Five marimo notebooks plus three evaluation harnesses live under `demo/`:
 - `demo/demo_semantic_field.py`: SemanticField Layer 2 — interactive director + genre query against MetaQA, with live scoring.
 - `demo/demo_discovery.py`: DiscoveryEngine Layer 3 — beam search over the EM field, find_paths and extract_circuit against the sample graph.
 - `demo/semantic_field_explainer.html`: full visual explainer for SemanticField — circuit diagram, layer stack, why EM, 1/2/multi-hop examples, test results. Open in any browser.
-- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; both share the setup and scoring loop in `demo/qa_eval_lib.py`.
+- `demo/eval_arch1_vs_arch2.py`, `demo/eval_qa_accuracy.py` and `demo/eval_qa_accuracy_2hop.py`: evaluation harnesses comparing plain traversal vs. ontology-guided traversal, all three sharing setup and hop primitives from `demo/qa_eval_lib.py`. `eval_qa_accuracy.py` scores the 1-hop question set and `eval_qa_accuracy_2hop.py` its 2-hop sibling; only those two also share the scoring loop.
 
 Install the demo extras and open any notebook:
 
@@ -227,7 +227,7 @@ no network, no external services.
 
 ## Data and acknowledgments
 
-The ontology demo and the two evaluation harnesses run against a small
+The ontology demo and the three evaluation harnesses run against a small
 hand-authored sample of public movie facts (`demo/data/sample_kb.txt`) written
 in the triple format of the MetaQA dataset (Zhang, Yuyu et al., "Variational
 Reasoning for Question Answering with Knowledge Graph", AAAI 2018,

--- a/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
+++ b/open_kgo/feature_groups/kg/embedded/tests/test_networkx_embedded.py
@@ -18,6 +18,21 @@ from open_kgo.feature_groups.kg.tests._helpers import make_valid_credentials
 
 
 _FIXTURE_GML = Path(__file__).parent / "fixtures" / "triangle.gml"
+_FIXTURE_DIRECTED_GML = Path(__file__).parent / "fixtures" / "directed_chain.gml"
+
+# Same document the igraph sibling uses, so a difference between the two
+# backends cannot be blamed on the input.
+_GRAPHML_CHAIN = """<?xml version="1.0" encoding="UTF-8"?>
+<graphml xmlns="http://graphml.graphdrawing.org/xmlns">
+  <graph id="G" edgedefault="directed">
+    <node id="alice"/>
+    <node id="bob"/>
+    <node id="carol"/>
+    <edge source="alice" target="bob"/>
+    <edge source="bob" target="carol"/>
+  </graph>
+</graphml>
+"""
 
 
 class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
@@ -58,3 +73,32 @@ class TestNetworkxEmbeddedReader(EmbeddedContractTestBase):
         )
         rows = run_query("networkx_embedded", self.valid_credentials()["networkx_embedded"], feat)
         assert sorted(r["node"] for r in rows) == ["bob", "carol"]
+
+    def test_edges_operation(self) -> None:
+        """``operation=edges`` is advertised in SUPPORTED_VALUES and dispatched in _load_rows, but was never asserted."""
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        slot = {"locator": str(_FIXTURE_DIRECTED_GML), "graph_file_format": "gml"}
+        feat = Feature("networkx_embedded__edges", options=Options(context={"operation": "edges"}))
+        rows = run_query("networkx_embedded", slot, feat)
+        assert sorted((r["src"], r["dst"]) for r in rows) == [("alice", "bob"), ("bob", "carol")]
+
+    def test_graphml_format_loads_and_returns_rows(self, tmp_path: Path) -> None:
+        """``graph_file_format=graphml`` maps to nx.read_graphml in _LOADERS; prove that path works.
+
+        Asserts nodes and edges from one tmp_path-written GraphML document, so
+        the advertised format is exercised end to end rather than only declared.
+        """
+        from open_kgo.feature_groups.kg.tests._helpers import run_query
+
+        graphml_path = tmp_path / "chain.graphml"
+        graphml_path.write_text(_GRAPHML_CHAIN, encoding="utf-8")
+        slot = {"locator": str(graphml_path), "graph_file_format": "graphml"}
+
+        nodes_feat = Feature("networkx_embedded__graphml_nodes", options=Options(context={"operation": "nodes"}))
+        node_rows = run_query("networkx_embedded", slot, nodes_feat)
+        assert sorted(r["node"] for r in node_rows) == ["alice", "bob", "carol"]
+
+        edges_feat = Feature("networkx_embedded__graphml_edges", options=Options(context={"operation": "edges"}))
+        edge_rows = run_query("networkx_embedded", slot, edges_feat)
+        assert sorted((r["src"], r["dst"]) for r in edge_rows) == [("alice", "bob"), ("bob", "carol")]

--- a/tests/test_metaqa_build_sample.py
+++ b/tests/test_metaqa_build_sample.py
@@ -20,6 +20,33 @@ def test_load_kb_parses_pipe_separated_triples() -> None:
     assert {"directed_by", "starred_actors", "has_genre"} <= relations
 
 
+def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
+    """Blank and not-exactly-3-field lines are skipped, not parsed and not raised on.
+
+    Written to a tmp_path file rather than the shared tiny_kb.txt fixture so the
+    other tests reading that fixture keep their exact expected edge set.
+    """
+    kb = tmp_path / "messy_kb.txt"
+    kb.write_text(
+        "\n".join(
+            [
+                "Movie1|directed_by|Director1",
+                "",  # blank
+                "   ",  # whitespace only, blank after strip()
+                "Movie1|directed_by",  # 2 fields
+                "Movie1|directed_by|Director1|extra",  # 4 fields
+                "Movie1",  # 1 field, no separator at all
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    g = build_sample.load_kb(kb)
+
+    assert list(g.edges(data="relation")) == [("Movie1", "Director1", "directed_by")]
+
+
 def test_read_topic_entities_extracts_brackets() -> None:
     topics = build_sample.read_topic_entities([TINY_QA])
     assert topics == {"Movie1", "Movie2"}

--- a/tests/test_metaqa_build_sample.py
+++ b/tests/test_metaqa_build_sample.py
@@ -23,8 +23,11 @@ def test_load_kb_parses_pipe_separated_triples() -> None:
 def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
     """Blank and not-exactly-3-field lines are skipped, not parsed and not raised on.
 
-    Written to a tmp_path file rather than the shared tiny_kb.txt fixture so the
-    other tests reading that fixture keep their exact expected edge set.
+    Written to a tmp_path file rather than the shared tiny_kb.txt fixture to keep
+    these malformed-line cases local to this test. load_kb skips them regardless
+    of which file they live in, so appending them to tiny_kb.txt would not have
+    changed any other test's parsed edge set; a dedicated file is fixture hygiene,
+    not a correctness requirement.
     """
     kb = tmp_path / "messy_kb.txt"
     kb.write_text(
@@ -45,6 +48,7 @@ def test_load_kb_skips_blank_and_malformed_lines(tmp_path: Path) -> None:
     g = build_sample.load_kb(kb)
 
     assert list(g.edges(data="relation")) == [("Movie1", "Director1", "directed_by")]
+    assert g.number_of_nodes() == 2
 
 
 def test_read_topic_entities_extracts_brackets() -> None:


### PR DESCRIPTION
Cherry-picks the 5 commits from dchaudhari7177's open PRs #77, #78, #79, #80, #81 (unmodified, same author, applied in order) onto a fresh branch off main, then adds one consolidated fix commit addressing what a thorough review of each surfaced. Closes #72, #73, #74, #75, #76.

The originals (#77-#81) are left open and untouched.

**Cherry-picked commits (unchanged):**
- `chore(ci): let Dependabot watch the GitHub Actions ecosystem` (#77)
- `docs: correct the demo notebook and eval harness counts in the README` (#78)
- `docs: link the GitHub workflows page from the README and CONTRIBUTING` (#79)
- `test: cover load_kb's blank and malformed line skips` (#80)
- `test: cover the edges operation and graphml format for NetworkxEmbeddedReader` (#81)

**Fix commit, addressing review findings on 3 of the 5** (#79 and #81 came back clean):

- `.github/dependabot.yml` (#77): the new `github-actions` entry had no `cooldown`, unlike this project's documented supply-chain buffering philosophy (`pyproject.toml`'s 7-day `uv` `exclude-newer`). Added a matching `cooldown.default-days: 7`.
- `README.md` (#78): the Demos section fix left an identical stale count two paragraphs later ("the two evaluation harnesses"), self-contradicting the "three" just introduced above it. Also tightened the eval-harnesses bullet so it doesn't imply `eval_arch1_vs_arch2.py` shares nothing with `qa_eval_lib.py`: it shares setup and hop primitives with the other two notebooks, just not their QA scoring loop.
- `tests/test_metaqa_build_sample.py` (#80): the new test's docstring gave the wrong reason for using `tmp_path` (`tiny_kb.txt`'s edge set would in fact be unaffected either way, since `load_kb` skips malformed lines regardless of file); corrected to fixture hygiene. Also asserts `number_of_nodes()` alongside the edges check, so a future regression that creates a node before the field-count guard would be caught.

`tox` passes on this branch (1047 passed, 57 skipped; ruff format/check, mypy --strict, bandit all clean).